### PR TITLE
Add python-netaddr library dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -19,5 +19,5 @@ Description: This package contains base layer 3 functionality for the Openswitch
 
 Package: opx-nas-l3
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, opx-cps, python-opx-cps
+Depends: ${shlibs:Depends}, ${misc:Depends}, opx-cps, python-opx-cps, python-netaddr
 Description: This package contains base layer 3 functionality for the Openswitch software.


### PR DESCRIPTION
Add python-netaddr library dependency to run routing functionality related  python scripts