### PR TITLE
Routing VRF, bugfixes and updates

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,8 @@ libopx_hal_routing_la_SOURCES=src/hal_rt_arp.c src/hal_rt_host.c  src/hal_rt_mpa
                               src/nas_rt_api.c src/nas_rt_nht.c src/hal_rt_debug.c  src/hal_rt_main.c \
                               src/hal_rt_mpath_grp.c src/hal_rt_route.c src/nas_rt_cps.c src/hal_rt_dr.c \
                               src/hal_rt_mem.c src/hal_rt_mpath_util.c src/hal_rt_util.cpp \
-                              src/nas_rt_mac.cpp src/hal_rt_intf_util.c
+                              src/nas_rt_mac.cpp src/hal_rt_intf_util.c src/hal_rt_offload.cpp \
+                              src/nas_rt_virt_routing.cpp
 
 libopx_hal_routing_la_CPPFLAGS= -D_FILE_OFFSET_BITS=64 -I$(top_srcdir)/inc/opx -I$(includedir)/opx $(COMMON_HARDEN_FLAGS) -fPIC
 
@@ -34,7 +35,7 @@ base_nbr_mgr_svc_CXXFLAGS=-std=c++11
 
 base_nbr_mgr_svc_SOURCES=nbr-mgr/src/nbr_mgr_main.cpp nbr-mgr/src/nbr_mgr_utils.cpp
 base_nbr_mgr_svc_SOURCES+=nbr-mgr/src/nbr_mgr_cps.cpp nbr-mgr/src/nbr_mgr_msgq.cpp
-base_nbr_mgr_svc_SOURCES+=nbr-mgr/src/nbr_mgr_proc.cpp nbr-mgr/src/nbr_mgr_timer.cpp
+base_nbr_mgr_svc_SOURCES+=nbr-mgr/src/nbr_mgr_proc.cpp nbr-mgr/src/nbr_mgr_timer.cpp nbr-mgr/src/nbr_mgr_debug.cpp
 base_nbr_mgr_svc_SOURCES+=nbr-mgr/src/nbr_mgr_nl_evt.cpp nbr-mgr/src/nbr_mgr_rslv.cpp
 
 base_nbr_mgr_svc_LDADD=-lopx_nas_linux -lopx_common -lopx_logging -lopx_cps_api_common -lsystemd

--- a/configure.ac
+++ b/configure.ac
@@ -1,11 +1,12 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-l3], [3.2.0+opx4], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-l3], [3.6.0], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIRS([m4])
+AM_MAINTAINER_MODE([enable])
 # Checks for programs.
 AC_PROG_CXX
 AC_PROG_CC

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+opx-nas-l3 (3.6.0) unstable; urgency=medium
+
+  * Feature: Routing VRF
+  * Update: ICMP Redirect support
+  * Update: Data VRF support in NAS-l3
+  * Update: Program loopback address in NPU
+  * Update: Added support for virtual routing IP configuration to configure peer's link local
+            address in hardware.
+  * Bugfix: Update the mgmt route status when the default route with eth0 is getting replaced 
+            with default route with null interface.
+
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 25 May 2018 15:00:00 -0800
+
 opx-nas-l3 (3.2.0+opx4) unstable; urgency=medium
 
   * Update: Add compiler/linker hardening flags

--- a/debian/control
+++ b/debian/control
@@ -18,10 +18,10 @@ Description: This package contains base layer 3 functionality for the Openswitch
 
 Package: libopx-nas-l3-dev
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends},libopx-common-dev (>= 1.4.0),libopx-nas-common-dev (>= 6.1.0),
-          libopx-cps-dev (>= 3.6.2),libopx-logging-dev (>= 2.1.0),libopx-nas-linux-dev (>= 5.11.0),
-          libopx-nas-ndi-dev (>= 3.26.0),opx-ndi-api-dev (>= 6.12.0),libopx-nas-l3-1 (=${binary:Version}),
-          libopx-base-model-dev (>= 3.109.0)
+Depends: ${misc:Depends},libopx-common-dev (>= 1.4.0),libopx-nas-common-dev (>= 6.1.0),
+         libopx-cps-dev (>= 3.6.2),libopx-logging-dev (>= 2.1.0),libopx-nas-linux-dev (>= 5.11.0),
+         libopx-nas-ndi-dev (>= 3.26.0),opx-ndi-api-dev (>= 6.12.0),libopx-nas-l3-1 (=${binary:Version}),
+         libopx-base-model-dev (>= 3.109.0)
 Description: This package contains base layer 3 functionality for the Openswitch software.
 
 Package: opx-nas-l3

--- a/inc/opx/hal_rt_api.h
+++ b/inc/opx/hal_rt_api.h
@@ -101,4 +101,6 @@ t_std_error hal_form_nbr_entry(ndi_neighbor_t *p_nbr_entry, t_fib_nh *p_nh);
 dn_hal_route_err hal_fib_next_hop_del(t_fib_nh *p_nh);
 dn_hal_route_err hal_fib_next_hop_add(t_fib_nh *p_nh);
 
+t_std_error _hal_rt_virtual_routing_ip_cfg(nas_rt_virtual_routing_ip_config_t *p_cfg, bool status);
+
 #endif /* __HAL_RT_API_H__ */

--- a/inc/opx/hal_rt_util.h
+++ b/inc/opx/hal_rt_util.h
@@ -111,12 +111,11 @@ ndi_rif_id_t hal_rif_id_get (npu_id_t npu_id, hal_vrf_id_t vrf_id, hal_ifindex_t
 
 ndi_vrf_id_t hal_vrf_obj_get (npu_id_t npu_id, hal_vrf_id_t vrf_id);
 
-uint32_t hal_rt_rif_ref_inc(hal_ifindex_t if_index);
+uint32_t hal_rt_rif_ref_inc(hal_vrf_id_t vrf_id, hal_ifindex_t if_index);
 
-bool hal_rt_rif_ref_dec(hal_ifindex_t if_index);
-int hal_rt_rif_ref_get(hal_ifindex_t if_index);
-t_std_error hal_rif_info_get (hal_ifindex_t if_index, ndi_rif_id_t *rif_id, uint32_t *ref_count);
-hal_ifindex_t hal_rt_rif_entry_get_next_if_index (hal_ifindex_t if_index);
+bool hal_rt_rif_ref_dec(hal_vrf_id_t vrf_id, hal_ifindex_t if_index);
+int hal_rt_rif_ref_get(hal_vrf_id_t vrf_id, hal_ifindex_t if_index);
+t_std_error hal_rif_info_get (hal_vrf_id_t vrf_id, hal_ifindex_t if_index, ndi_rif_id_t *rif_id, uint32_t *ref_count);
 
 bool hal_rt_is_intf_lpbk (hal_vrf_id_t vrf_id, hal_ifindex_t if_index);
 bool hal_rt_is_intf_mgmt (hal_vrf_id_t vrf_id, hal_ifindex_t if_index);
@@ -130,20 +129,41 @@ int nas_rt_process_msg(t_fib_msg *p_msg);
 int fib_msg_main(void);
 bool nas_rt_peer_mac_db_add (nas_rt_peer_mac_config_t* mac_info);
 t_std_error nas_route_delete_vrf_peer_mac_config(uint32_t vrf_id);
+t_std_error nas_route_delete_vrf_virtual_routing_ip_config(uint32_t vrf_id);
 bool nas_rt_peer_mac_get (const nas_rt_peer_mac_config_t* req,
                           nas_rt_peer_mac_config_t* reply_p);
 bool nas_rt_peer_mac_db_del (nas_rt_peer_mac_config_t* mac_info);
 cps_api_object_t nas_route_peer_routing_config_to_cps_object(uint32_t vrf_id,
                                                              nas_rt_peer_mac_config_t *p_status);
+bool nas_rt_virtual_routing_ip_db_add (nas_rt_virtual_routing_ip_config_t * ip_info);
+bool nas_rt_virtual_routing_ip_db_del (nas_rt_virtual_routing_ip_config_t * ip_info);
+bool nas_rt_virtual_routing_ip_get (const nas_rt_virtual_routing_ip_config_t * req,
+                                    nas_rt_virtual_routing_ip_config_t* reply_p);
+uint32_t nas_rt_virtual_routing_ip_list_size (const nas_rt_virtual_routing_ip_config_t * req);
+cps_api_object_t nas_route_virtual_routing_ip_config_to_cps_object(uint32_t vrf_id,
+                                              nas_rt_virtual_routing_ip_config_t *p_status);
 bool nas_rt_is_nh_npu_prg_done(t_fib_nh *p_entry);
 void hal_rt_sort_array(uint64_t data[], uint32_t count);
 const char *hal_rt_intf_mode_to_str (uint32_t mode);
-t_std_error hal_rt_get_if_index_from_if_name(char *if_name, uint32_t *p_if_index);
+t_std_error hal_rt_get_if_index_from_if_name(char *if_name, hal_vrf_id_t *vrf_id, uint32_t *p_if_index);
 bool hal_rt_is_intf_mac_vlan (hal_vrf_id_t vrf_id, hal_ifindex_t if_index);
 bool hal_rt_get_vrf_id(const char *vrf_name, hal_vrf_id_t *vrf_id);
 bool hal_rt_get_vrf_name(hal_vrf_id_t vrf_id, char *vrf_name);
 int fib_process_route_del_on_mgmt_ip_del_event (hal_ifindex_t if_index, hal_vrf_id_t vrf_id,
                                                 t_fib_ip_addr *prefix, uint8_t prefix_len);
 int nas_rt_get_mask (uint8_t af_index, uint8_t prefix_len, t_fib_ip_addr *mask);
+bool hal_rt_is_local_ip_conflict(hal_vrf_id_t vrf_id, hal_ip_addr_t *nbr);
+int fib_route_del_on_intf_down (t_fib_intf *p_intf);
+int fib_process_link_local_address_del_on_intf_event (t_fib_intf *p_intf, t_fib_intf_event_type intf_event);
+int fib_process_nh_del_on_intf_event (t_fib_intf *p_intf, t_fib_intf_event_type intf_event);
+t_std_error hal_rt_get_parent_if_index_from_l3_intf(hal_vrf_id_t vrf_id, uint32_t if_index,
+                                                    uint32_t *p_parent_if_index);
+bool hal_rt_flush_vrf_info(hal_vrf_id_t vrf_id);
+int fib_process_route_del_on_intf_event (t_fib_intf *p_intf, t_fib_intf_event_type intf_event);
+bool hal_rt_form_neigh_flush_msg (t_fib_offload_msg *p_offload_msg, t_fib_dr *p_dr,
+                                  bool is_neigh_flush_with_intf, hal_ifindex_t if_index);
+int nas_rt_process_offload_msg(t_fib_offload_msg *p_offload_msg);
+int fib_offload_msg_main(void);
+bool hal_rt_is_vrf_valid(hal_vrf_id_t vrf_id);
 #endif /* __HAL_RT_UTIL_H__ */
 

--- a/inc/opx/nas_rt_api.h
+++ b/inc/opx/nas_rt_api.h
@@ -123,9 +123,16 @@ t_std_error nas_route_get_all_arp_info(cps_api_object_list_t list, uint32_t vrf_
                                        hal_ip_addr_t *p_nh_addr, bool is_specific_nh_get,
                                        bool is_proactive_nh_get);
 
-t_std_error nas_route_process_cps_peer_routing(cps_api_transaction_params_t * param,
+cps_api_return_code_t nas_route_process_cps_peer_routing(cps_api_transaction_params_t * param,
                                         size_t ix);
 t_std_error nas_route_get_all_peer_routing_config(cps_api_object_list_t list);
+
+cps_api_return_code_t nas_route_process_cps_virtual_routing_ip_cfg (cps_api_transaction_params_t * param,
+                                        size_t ix);
+t_std_error nas_route_get_all_virtual_routing_ip_config (cps_api_object_list_t list,
+                                        bool show_all,
+                                        nas_rt_virtual_routing_ip_config_t *p_cfg);
+
 t_std_error nas_route_process_cps_nht(cps_api_transaction_params_t * param, size_t ix);
 int nas_rt_publish_nht(t_fib_nht *p_nht, t_fib_dr *p_dr, t_fib_nh *p_nh, bool is_add);
 
@@ -135,7 +142,8 @@ t_fib_nht *fib_get_next_nht (uint32_t vrf_id, t_fib_ip_addr *p_dest_addr);
 t_std_error nas_route_get_all_nht_info(cps_api_object_list_t list, unsigned int vrf_id,
                                        unsigned int af, t_fib_ip_addr *p_dest_addr);
 t_std_error nas_route_get_all_route_info(cps_api_object_list_t list, uint32_t vrf_id, uint32_t af,
-                                         hal_ip_addr_t *p_prefix, uint32_t pref_len, bool is_specific_prefix_get);
+                                         hal_ip_addr_t *p_prefix, uint32_t pref_len, bool is_specific_prefix_get,
+                                         bool is_specific_vrf_get);
 cps_api_object_t nas_route_nh_to_nbr_cps_object(t_fib_nh *entry, cps_api_operation_types_t op, bool is_pub);
 bool nas_route_fdb_add_cps_msg (t_fib_nh *p_nh);
 
@@ -144,6 +152,9 @@ cps_api_return_code_t nas_route_process_cps_ip_unreachables_msg(cps_api_transact
 cps_api_return_code_t nas_route_get_all_ip_unreach_info(cps_api_object_list_t list, uint32_t af, char *if_name,
                                               bool is_specific_get);
 cps_api_return_code_t nas_route_os_ip_unreachable_config(uint32_t af, char *if_name, bool is_del, bool is_enable);
+cps_api_return_code_t nas_route_process_cps_ip_redirects_msg(cps_api_transaction_params_t * param, size_t ix);
+cps_api_return_code_t nas_route_get_all_ip_redirects_info (cps_api_object_list_t list,
+                                                           hal_vrf_id_t vrf_id, char *if_name);
 bool nas_route_publish_route(t_fib_dr *p_dr, t_fib_rt_msg_type type);
 cps_api_return_code_t nas_route_handle_event_filter(cps_api_transaction_params_t * param, size_t ix);
 cps_api_return_code_t nas_route_get_all_event_filter_info(cps_api_object_list_t list);

--- a/inc/opx/nbr-mgr/nbr_mgr_main.h
+++ b/inc/opx/nbr-mgr/nbr_mgr_main.h
@@ -46,6 +46,7 @@
 
 #define NBR_MGR_INTF_ADMIN_MSG 0x1
 #define NBR_MGR_INTF_VLAN_MSG  0x2
+#define NBR_MGR_DEFAULT_VRF_ID 0
 
 enum {
     NBR_MGR_AUTO_REFRESH_INIT,
@@ -64,7 +65,7 @@ bool nbr_mgr_program_npu(nbr_mgr_op_t op, const nbr_mgr_nbr_entry_t& entry);
 bool nbr_mgr_notify_intf_status(nbr_mgr_op_t op, const nbr_mgr_intf_entry_t& entry);
 bool nbr_mgr_get_all_nh(uint8_t af);
 
-int nbr_mgr_enqueue_flush_msg(uint32_t if_index);
+int nbr_mgr_enqueue_flush_msg(uint32_t if_index, hal_vrf_id_t vrf_id);
 bool nbr_mgr_get_auto_refresh_status (const char *vrf_name, uint32_t family);
 bool nbr_mgr_is_mac_present_in_hw(hal_mac_addr_t mac, hal_ifindex_t if_index,
                                   bool& is_mac_present_in_hw);

--- a/nbr-mgr/src/nbr_mgr_debug.cpp
+++ b/nbr-mgr/src/nbr_mgr_debug.cpp
@@ -1,0 +1,397 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN  *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * filename: nbr_mgr_debug.cpp
+ */
+
+#include "nbr_mgr_main.h"
+#include "nbr_mgr_cache.h"
+#include "nbr_mgr_log.h"
+#include <exception>
+#include <sstream>
+
+extern nbr_process* p_nbr_process_hdl;
+extern char *nbr_mgr_nl_neigh_state_to_str (int state);
+
+void nbr_process::nbr_mgr_dump_process_stats() {
+    NBR_MGR_LOG_ERR("STATS", " NBR_MGR Stats INTF add:%d,del:%d,NBR add:%d,incomplete:%d,reachable:%d,stale:%d,"
+                    "delay:%d,probe:%d,failed:%d,permanent:%d,del:%d, RESOLVE add:%d del%d FDB add:%d del:%d"
+                    " FLUSH:%d trig_refresh:%d,dup_trig_nbr:%d",
+                    stats.intf_add_msg_cnt,  stats.intf_del_msg_cnt, stats.nbr_add_msg_cnt,
+                    stats.nbr_add_incomplete_msg_cnt, stats.nbr_add_reachable_msg_cnt, stats.nbr_add_stale_msg_cnt,
+                    stats.nbr_add_delay_msg_cnt, stats.nbr_add_probe_msg_cnt, stats.nbr_add_failed_msg_cnt,
+                    stats.nbr_add_permanaent_cnt, stats.nbr_del_msg_cnt,
+                    stats.nbr_rslv_add_msg_cnt, stats.nbr_rslv_del_msg_cnt,
+                    stats.fdb_add_msg_cnt, stats.fdb_del_msg_cnt, stats.flush_msg_cnt,
+                    stats.flush_trig_refresh_cnt, stats.flush_nbr_cnt);
+}
+
+static void _nbr_mgr_dump_nbr_data_stats(nbr_data const * ptr) {
+    NBR_MGR_LOG_ERR("DUMP", "Neighbor STATS vrf-id:%d Nbr:%s refresh:%d delay refresh:%d resolve:%d "
+                    "retry:%d mac_np:%d fail_trig:%d stale_ref:%d hw_mac_lrn_refresh:%d mac_trig_ref:%d "
+                    "FLUSH skip:%d fail_resolve:%d refresh:%d",
+                    ptr->get_vrf_id(), ptr->get_ip_addr().c_str(),
+                    ptr->nbr_stats.refresh_cnt, ptr->nbr_stats.delay_refresh_cnt, ptr->nbr_stats.resolve_cnt,
+                    ptr->nbr_stats.retry_cnt, ptr->nbr_stats.mac_not_present_cnt,
+                    ptr->nbr_stats.failed_trig_resolve_cnt, ptr->nbr_stats.stale_trig_refresh_cnt,
+                    ptr->nbr_stats.hw_mac_learn_refresh_cnt, ptr->nbr_stats.mac_trig_refresh,
+                    ptr->nbr_stats.flush_skip_refresh, ptr->nbr_stats.flush_failed_resolve,
+                    ptr->nbr_stats.flush_refresh);
+}
+
+static void _nbr_mgr_dump_nbr_data_ref_stats(nbr_data_ptr &ptr) {
+    NBR_MGR_LOG_ERR("DUMP", "Neighbor STATS vrf-id:%d Nbr:%s refresh:%d delay refresh:%d resolve:%d "
+                    "retry:%d mac_np:%d fail_trig:%d stale_ref:%d hw_mac_lrn_refresh:%d mac_trig_ref:%d "
+                    "FLUSH skip:%d fail_resolve:%d refresh:%d",
+                    ptr->get_vrf_id(), ptr->get_ip_addr().c_str(),
+                    ptr->nbr_stats.refresh_cnt, ptr->nbr_stats.delay_refresh_cnt, ptr->nbr_stats.resolve_cnt,
+                    ptr->nbr_stats.retry_cnt, ptr->nbr_stats.mac_not_present_cnt,
+                    ptr->nbr_stats.failed_trig_resolve_cnt, ptr->nbr_stats.stale_trig_refresh_cnt,
+                    ptr->nbr_stats.hw_mac_learn_refresh_cnt, ptr->nbr_stats.mac_trig_refresh,
+                    ptr->nbr_stats.flush_skip_refresh, ptr->nbr_stats.flush_failed_resolve,
+                    ptr->nbr_stats.flush_refresh);
+}
+
+static nbr_mgr_nbr_stats gbl_nbr_stats;
+static void nbr_mgr_dump_all_nbr_data_stats(nbr_data const * ptr) {
+    gbl_nbr_stats.refresh_cnt += ptr->nbr_stats.refresh_cnt;
+    gbl_nbr_stats.delay_refresh_cnt += ptr->nbr_stats.delay_refresh_cnt;
+    gbl_nbr_stats.resolve_cnt += ptr->nbr_stats.resolve_cnt;
+    gbl_nbr_stats.retry_cnt += ptr->nbr_stats.retry_cnt;
+    gbl_nbr_stats.mac_not_present_cnt += ptr->nbr_stats.mac_not_present_cnt;
+    gbl_nbr_stats.failed_trig_resolve_cnt += ptr->nbr_stats.failed_trig_resolve_cnt;
+    gbl_nbr_stats.stale_trig_refresh_cnt += ptr->nbr_stats.stale_trig_refresh_cnt;
+    gbl_nbr_stats.hw_mac_learn_refresh_cnt += ptr->nbr_stats.hw_mac_learn_refresh_cnt;
+    gbl_nbr_stats.mac_trig_refresh += ptr->nbr_stats.mac_trig_refresh;
+    gbl_nbr_stats.flush_skip_refresh += ptr->nbr_stats.flush_skip_refresh;
+    gbl_nbr_stats.flush_failed_resolve += ptr->nbr_stats.flush_failed_resolve;
+    gbl_nbr_stats.flush_refresh += ptr->nbr_stats.flush_refresh;
+
+}
+
+void _nbr_mgr_dump_all_nbr_stats() {
+    memset(&gbl_nbr_stats, 0, sizeof(gbl_nbr_stats));
+    p_nbr_process_hdl->nbr_db_walk(nbr_mgr_dump_all_nbr_data_stats);
+    NBR_MGR_LOG_ERR("DUMP", "All neighbor STATS refresh:%d delay refresh:%d resolve:%d "
+                    "retry:%d mac_np:%d fail_trig:%d stale_ref:%d mac_lrn_ref:%d mac_trig_ref:%d "
+                    "FLUSH skip:%d fail_resolve:%d refresh:%d",
+                    gbl_nbr_stats.refresh_cnt, gbl_nbr_stats.delay_refresh_cnt, gbl_nbr_stats.resolve_cnt,
+                    gbl_nbr_stats.retry_cnt, gbl_nbr_stats.mac_not_present_cnt,
+                    gbl_nbr_stats.failed_trig_resolve_cnt, gbl_nbr_stats.stale_trig_refresh_cnt,
+                    gbl_nbr_stats.hw_mac_learn_refresh_cnt, gbl_nbr_stats.mac_trig_refresh,
+                    gbl_nbr_stats.flush_skip_refresh, gbl_nbr_stats.flush_failed_resolve,
+                    gbl_nbr_stats.flush_refresh);
+}
+
+void _nbr_mgr_dump_all_nbr_stats_clear(nbr_data const * ptr) {
+    memset(&(ptr->nbr_stats), 0, sizeof(ptr->nbr_stats));
+}
+
+void nbr_mgr_dump_mac_data(mac_data_ptr ptr) {
+    NBR_MGR_LOG_ERR("DUMP", "MAC entry MAC:%s, ifindex:%d, mbr_if_index:%d, FDB type:%d",
+                    ptr->get_mac_addr().c_str(), ptr->get_mac_intf(),
+                    ptr->get_mac_phy_if(), static_cast<int>(ptr->get_fdb_type()));
+}
+
+
+void _nbr_mgr_dump_macs(nbr_mgr_dump_entry_t &dump) {
+    if (p_nbr_process_hdl) {
+        if (dump.if_index) {
+            p_nbr_process_hdl->mac_if_db_walk(dump.if_index, nbr_mgr_dump_mac_data);
+        } else {
+            p_nbr_process_hdl->mac_db_walk(nbr_mgr_dump_mac_data);
+        }
+    }
+}
+
+void nbr_mgr_dump_intf_data(nbr_mgr_intf_entry_t intf) {
+    NBR_MGR_LOG_ERR("DUMP", "Intf entry VRF-id:%d ifindex:%d, is_admin_up:%d, VlanId:%d, flags:0x%x hlayer VRF:%d if-index:%d",
+                    intf.vrfid, intf.if_index, intf.is_admin_up, intf.vlan_id, intf.flags,
+                    intf.parent_or_child_vrfid, intf.parent_or_child_if_index);
+}
+
+void _nbr_mgr_dump_intf(nbr_mgr_dump_entry_t &dump) {
+    if (p_nbr_process_hdl == nullptr) return;
+
+    if (dump.is_dump_all) {
+        p_nbr_process_hdl->nbr_if_list_walk(nbr_mgr_dump_intf_data);
+    } else {
+        p_nbr_process_hdl->nbr_if_list_entry_walk(dump.vrf_id, dump.if_index, nbr_mgr_dump_intf_data);
+    }
+}
+
+/* Dump global stats */
+void _nbr_mgr_dump_stats() {
+    if (p_nbr_process_hdl == nullptr) {
+        printf("Process is not spawned");
+        return;
+    }
+    p_nbr_process_hdl->nbr_mgr_dump_process_stats();
+    _nbr_mgr_dump_all_nbr_stats();
+}
+
+/* Clears global stats */
+void _nbr_mgr_stats_clear() {
+    if (p_nbr_process_hdl) {
+        memset(&(p_nbr_process_hdl->stats), 0, sizeof(nbr_mgr_stats));
+        p_nbr_process_hdl->nbr_db_walk(_nbr_mgr_dump_all_nbr_stats_clear);
+    }
+}
+
+void _nbr_mgr_dump_nbr_stats(nbr_mgr_dump_entry_t &dump) {
+    if (p_nbr_process_hdl == nullptr) return;
+
+    if (dump.is_dump_all) {
+        p_nbr_process_hdl->nbr_db_walk(_nbr_mgr_dump_nbr_data_stats);
+    } else {
+        p_nbr_process_hdl->nbr_if_db_walk(dump.vrf_id, dump.if_index, _nbr_mgr_dump_nbr_data_stats);
+    }
+}
+
+void _nbr_mgr_dump_nbr_stats_clear(nbr_mgr_dump_entry_t &dump) {
+    if (p_nbr_process_hdl == nullptr) return;
+
+    if (dump.is_dump_all) {
+        p_nbr_process_hdl->nbr_db_walk(_nbr_mgr_dump_all_nbr_stats_clear);
+    } else {
+        p_nbr_process_hdl->nbr_if_db_walk(dump.vrf_id, dump.if_index, _nbr_mgr_dump_all_nbr_stats_clear);
+    }
+}
+
+static void _nbr_mgr_dump_nbr_data(nbr_data const * ptr) {
+    NBR_MGR_LOG_ERR("DUMP", "Neighbor VRF:%s(%d) family:%d Nbr:%s, MAC:%s, ifindex:%d, llayer-index:%d status:%s(0x%x)"
+                    " flags:0x%x published:%d failed_cnt:%d retry_cnt:%d refresh_cnt:%d "
+                    "refresh_cnt_for_mac_learn prev:%d curr:%d npu_prg_msg_cnt:%d last_status_pub:%s(%x)",
+                    ptr->get_vrf_name().c_str(), ptr->get_vrf_id(), ptr->get_family(), ptr->get_ip_addr().c_str(),
+                    ((ptr->get_mac_ptr()) ? ptr->get_mac_ptr()->get_mac_addr().c_str() : nullptr),
+                    ptr->get_if_index(), ptr->get_parent_if_index(), nbr_mgr_nl_neigh_state_to_str (ptr->get_status()),
+                    ptr->get_status(), ptr->get_flags(), ptr->get_published(),
+                    ptr->get_failed_cnt(), ptr->get_retry_cnt(), ptr->get_refresh_cnt(),
+                    ptr->get_prev_refresh_for_mac_learn_retry_cnt(),
+                    ptr->get_refresh_for_mac_learn_retry_cnt(), ptr->nbr_stats.npu_prg_msg_cnt,
+                    nbr_mgr_nl_neigh_state_to_str(ptr->get_last_pub_status()), ptr->get_last_pub_status());
+    _nbr_mgr_dump_nbr_data_stats(ptr);
+    if (p_nbr_process_hdl) {
+        p_nbr_process_hdl->nbr_if_list_entry_walk(ptr->get_vrf_id(), ptr->get_if_index(), nbr_mgr_dump_intf_data);
+        if (ptr->get_if_index() != ptr->get_parent_if_index()) {
+            p_nbr_process_hdl->nbr_if_list_entry_walk(NBR_MGR_DEFAULT_VRF_ID, ptr->get_parent_if_index(), nbr_mgr_dump_intf_data);
+        }
+        try {
+            std::string mac = ptr->get_mac_ptr()->get_mac_addr().c_str();
+            nbr_mgr_dump_mac_data(p_nbr_process_hdl->mac_db_get(ptr->get_parent_if_index(), mac));
+        } catch(std::invalid_argument& e) {
+            NBR_MGR_LOG_ERR("DUMP", "MAC is not present");
+        }
+    }
+}
+
+static void _nbr_mgr_dump_nbr_ref(nbr_data_ptr &ptr) {
+    NBR_MGR_LOG_ERR("DUMP", "Neighbor VRF:%s(%d) family:%d Nbr:%s, MAC:%s, ifindex:%d, llayer-index:%d status:%s(0x%x)"
+                    " flags:0x%x published:%d failed_cnt:%d retry_cnt:%d refresh_cnt:%d "
+                    "refresh_cnt_for_mac_learn prev:%d curr:%d npu_prg_msg_cnt:%d last_status_pub:%s(%x)",
+                    ptr->get_vrf_name().c_str(), ptr->get_vrf_id(), ptr->get_family(), ptr->get_ip_addr().c_str(),
+                    ((ptr->get_mac_ptr()) ? ptr->get_mac_ptr()->get_mac_addr().c_str() : nullptr),
+                    ptr->get_if_index(), ptr->get_parent_if_index(), nbr_mgr_nl_neigh_state_to_str (ptr->get_status()),
+                    ptr->get_status(), ptr->get_flags(), ptr->get_published(),
+                    ptr->get_failed_cnt(), ptr->get_retry_cnt(), ptr->get_refresh_cnt(),
+                    ptr->get_prev_refresh_for_mac_learn_retry_cnt(),
+                    ptr->get_refresh_for_mac_learn_retry_cnt(), ptr->nbr_stats.npu_prg_msg_cnt,
+                    nbr_mgr_nl_neigh_state_to_str(ptr->get_last_pub_status()), ptr->get_last_pub_status());
+    _nbr_mgr_dump_nbr_data_ref_stats(ptr);
+    if (p_nbr_process_hdl) {
+        p_nbr_process_hdl->nbr_if_list_entry_walk(ptr->get_vrf_id(), ptr->get_if_index(), nbr_mgr_dump_intf_data);
+        if (ptr->get_if_index() != ptr->get_parent_if_index()) {
+            p_nbr_process_hdl->nbr_if_list_entry_walk(NBR_MGR_DEFAULT_VRF_ID, ptr->get_parent_if_index(), nbr_mgr_dump_intf_data);
+        }
+        p_nbr_process_hdl->mac_if_db_walk(ptr->get_parent_if_index(), nbr_mgr_dump_mac_data);
+    }
+}
+
+/* ARP/Neighbor dump, pass if-index 0 to dump all neighbors */
+void _nbr_mgr_dump_nbrs(nbr_mgr_dump_entry_t &dump) {
+    if (p_nbr_process_hdl == nullptr) return;
+
+    if (dump.is_dump_all) {
+        p_nbr_process_hdl->nbr_db_walk(_nbr_mgr_dump_nbr_data);
+    } else {
+        p_nbr_process_hdl->nbr_if_db_walk(dump.vrf_id, dump.if_index, _nbr_mgr_dump_nbr_data);
+    }
+}
+
+inline std::string nbr_get_nbr_dump_key(hal_ifindex_t ifix, const std::string& ip) {
+    return (std::to_string(ifix) + "-" + ip);
+}
+
+static void _nbr_mgr_dump_nbr(nbr_mgr_dump_entry_t &dump) {
+
+    NBR_MGR_LOG_ERR("DUMP", "af:%d vrf-id:%d intf:%d Nbr:%s ", dump.af, dump.vrf_id,
+                    dump.if_index, dump.nbr_ip);
+    if (p_nbr_process_hdl == nullptr) {
+        return;
+    }
+
+    std::string ip(dump.nbr_ip);
+    std::string key = nbr_get_nbr_dump_key(dump.if_index, ip);
+
+    try {
+        nbr_ip_db_type& nbr_db = p_nbr_process_hdl->neighbor_db(dump.af);
+        auto &ptr = p_nbr_process_hdl->nbr_db_get(nbr_db, dump.vrf_id, key);
+        _nbr_mgr_dump_nbr_ref(ptr);
+
+    } catch (std::invalid_argument& e){
+        NBR_MGR_LOG_ERR("DUMP", "Nbr:%s does not exist! %s", dump.nbr_ip, e.what());
+        return;
+    }
+}
+
+
+
+bool nbr_process::nbr_proc_dump_msg(nbr_mgr_dump_entry_t& dump) {
+    NBR_MGR_LOG_ERR("PROC", "DUMP AF:%d VRF-id:%d Nbr-ip:%s Intf:%d type:%d is_dump_all:%d",
+                     dump.af, dump.vrf_id, dump.nbr_ip, dump.if_index, dump.type, dump.is_dump_all);
+
+    switch(dump.type) {
+        case NBR_MGR_DUMP_NBR:
+            _nbr_mgr_dump_nbr(dump);
+            break;
+        case NBR_MGR_DUMP_NBRS:
+            _nbr_mgr_dump_nbrs(dump);
+            break;
+        case NBR_MGR_DUMP_MACS:
+            _nbr_mgr_dump_macs(dump);
+            break;
+        case NBR_MGR_DUMP_INTF:
+            _nbr_mgr_dump_intf(dump);
+            break;
+        case NBR_MGR_DUMP_GBL_STATS:
+            _nbr_mgr_dump_stats();
+            break;
+        case NBR_MGR_DUMP_GBL_STATS_CLEAR:
+            _nbr_mgr_stats_clear();
+            break;
+        case NBR_MGR_DUMP_DETAIL_NBR_STATS:
+            _nbr_mgr_dump_nbr_stats(dump);
+            break;
+        case NBR_MGR_DUMP_DETAIL_NBR_STATS_CLEAR:
+            _nbr_mgr_dump_nbr_stats_clear(dump);
+            break;
+        default:
+            break;
+
+    }
+    return true;
+}
+
+bool nbr_mgr_dump_info(nbr_mgr_dump_entry_t *dump) {
+    nbr_mgr_msg_t *p_msg = nullptr;
+
+    NBR_MGR_LOG_ERR ("NAS_DUMP","DUMP msg to be enqueued for type:%d vrf-id:%d if-index:%d is_dump_all:%d",
+                      dump->type, dump->vrf_id, dump->if_index, dump->is_dump_all);
+    nbr_mgr_msg_uptr_t p_msg_uptr = nbr_mgr_alloc_unique_msg(&p_msg);
+    if (p_msg == NULL) {
+        NBR_MGR_LOG_ERR ("NAS_DUMP","Memory alloc failed for NAS dump message");
+        return false;
+    }
+    memset(p_msg, 0, sizeof(nbr_mgr_msg_t));
+    p_msg->type = NBR_MGR_DUMP_MSG;
+    memcpy(&p_msg->dump, dump, sizeof(nbr_mgr_dump_entry_t));
+
+    nbr_mgr_enqueue_netlink_nas_msg(std::move(p_msg_uptr));
+    return true;
+}
+
+/*
+char *nbr_mgr_dump_help() {
+    std::stringstream ss;
+    ss << "nbr_mgr_dump_nbr(af,vrf_id,nbr_ip,if_index), nbr_mgr_dump_nbrs(vrf_id,if_index), \
+        nbr_mgr_dump_mac(vrf_id,if_index), nbr_mgr_dump_intf(vrf_id, if_index), \
+        nbr_mgr_dump_stats(), nbr_mgr_dump_stats_clear(), nbr_mgr_dump_nbr_stats(vrf_id, if_index), \
+        nbr_mgr_dump_nbr_stats_clear(vrf_id,if_index)";
+    return ss.str().c_str();
+}
+*/
+
+/* Use the following functions for dumping the neighbor information and stats */
+void nbr_mgr_dump_nbr(uint32_t af, uint32_t vrf_id, const char *nbr_ip, uint32_t if_index) {
+    if (nbr_ip == nullptr) {
+        return;
+    }
+    nbr_mgr_dump_entry_t dump;
+    memset(&dump, 0, sizeof(dump));
+    dump.af = af;
+    dump.vrf_id = vrf_id;
+    strncpy(dump.nbr_ip, nbr_ip, sizeof(dump.nbr_ip));
+    dump.if_index = if_index;
+    dump.type = NBR_MGR_DUMP_NBR;
+    nbr_mgr_dump_info(&dump);
+}
+void nbr_mgr_dump_nbrs(bool is_dump_all, uint32_t vrf_id, uint32_t if_index) {
+    nbr_mgr_dump_entry_t dump;
+    memset(&dump, 0, sizeof(dump));
+    dump.vrf_id = vrf_id;
+    dump.if_index = if_index;
+    dump.is_dump_all = is_dump_all;
+    dump.type = NBR_MGR_DUMP_NBRS;
+    nbr_mgr_dump_info(&dump);
+}
+void nbr_mgr_dump_mac(uint32_t if_index) {
+    nbr_mgr_dump_entry_t dump;
+    memset(&dump, 0, sizeof(dump));
+    dump.if_index = if_index;
+    dump.type = NBR_MGR_DUMP_MACS;
+    nbr_mgr_dump_info(&dump);
+}
+void nbr_mgr_dump_intf(bool is_dump_all, uint32_t vrf_id, uint32_t if_index) {
+    nbr_mgr_dump_entry_t dump;
+    memset(&dump, 0, sizeof(dump));
+    dump.vrf_id = vrf_id;
+    dump.if_index = if_index;
+    dump.is_dump_all = is_dump_all;
+    dump.type = NBR_MGR_DUMP_INTF;
+    nbr_mgr_dump_info(&dump);
+}
+void nbr_mgr_dump_stats() {
+    nbr_mgr_dump_entry_t dump;
+    memset(&dump, 0, sizeof(dump));
+    dump.type = NBR_MGR_DUMP_GBL_STATS;
+    nbr_mgr_dump_info(&dump);
+}
+void nbr_mgr_dump_stats_clear() {
+    nbr_mgr_dump_entry_t dump;
+    memset(&dump, 0, sizeof(dump));
+    dump.type = NBR_MGR_DUMP_GBL_STATS_CLEAR;
+    nbr_mgr_dump_info(&dump);
+}
+void nbr_mgr_dump_nbr_stats(bool is_dump_all, uint32_t vrf_id, uint32_t if_index) {
+    nbr_mgr_dump_entry_t dump;
+    memset(&dump, 0, sizeof(dump));
+    dump.vrf_id = vrf_id;
+    dump.if_index = if_index;
+    dump.is_dump_all = is_dump_all;
+    dump.type = NBR_MGR_DUMP_DETAIL_NBR_STATS;
+    nbr_mgr_dump_info(&dump);
+}
+void nbr_mgr_dump_nbr_stats_clear(bool is_dump_all, uint32_t vrf_id, uint32_t if_index) {
+    nbr_mgr_dump_entry_t dump;
+    memset(&dump, 0, sizeof(dump));
+    dump.vrf_id = vrf_id;
+    dump.if_index = if_index;
+    dump.is_dump_all = is_dump_all;
+    dump.type = NBR_MGR_DUMP_DETAIL_NBR_STATS_CLEAR;
+    nbr_mgr_dump_info(&dump);
+}
+

--- a/nbr-mgr/src/nbr_mgr_msgq.cpp
+++ b/nbr-mgr/src/nbr_mgr_msgq.cpp
@@ -99,6 +99,10 @@ std::string nbr_mgr_msgq_t::queue_stats ()
     return ss.str();
 }
 
+std::string nbr_mgr_netlink_q_stats() {
+    return (p_msgq_nl_nas_msg_hdl->queue_stats());
+}
+
 bool nbr_mgr_enqueue_netlink_nas_msg(nbr_mgr_msg_uptr_t msg)
 {
     return (p_msgq_nl_nas_msg_hdl->enqueue(std::move(msg)));

--- a/src/hal_rt_mpath.c
+++ b/src/hal_rt_mpath.c
@@ -95,8 +95,8 @@ void hal_rt_format_nh_list(next_hop_id_t nh_list[],  int count, char *buf, int s
     hal_rt_format_nh_list(nh_list, p_route_entry->nhop_count, buf, HAL_RT_MAX_BUFSZ * 10);
 
     HAL_RT_LOG_DEBUG("HAL-RT-NDI",
-            "NH Group: VRF %d. Prefix: " "%s/%d flags 0x%x group type %d "
-            "nh_group_handle %d npu_id %d ecmp_count %d, next_hop_id_list hal_rt_format_nh_list: %s",
+            "NH Group: VRF %lu. Prefix: " "%s/%d flags 0x%x group type %d "
+            "nh_group_handle %lu npu_id %d ecmp_count %d, next_hop_id_list hal_rt_format_nh_list: %s",
             p_route_entry->vrf_id, FIB_IP_ADDR_TO_STR(&(p_route_entry->prefix)),
             p_route_entry->mask_len, p_route_entry->flags,
             p_route_entry->group_type, p_route_entry->nh_group_handle,
@@ -178,7 +178,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
                             removed_nh_group_entry.nh_list[removed_fh_count].weight = 1;
                             removed_fh_count++;
                             HAL_RT_LOG_INFO ("HAL-RT-MP", "VRF %d Prefix: %s/%d, "
-                                             "removed_fh_count:%d NH handle:%d ",
+                                             "removed_fh_count:%d NH handle:%lu ",
                                              p_dr->vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix), p_dr->prefix_len,
                                              removed_fh_count, p_fh->next_hop_id);
                         }
@@ -212,7 +212,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
                         removed_nh_group_entry.nh_list[removed_fh_count].weight = 1;
                         removed_fh_count++;
                         HAL_RT_LOG_INFO ("HAL-RT-MP", "VRF %d Prefix: %s/%d, "
-                                         "removed_fh_count:%d NH handle:%d ",
+                                         "removed_fh_count:%d NH handle:%lu ",
                                          p_dr->vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix), p_dr->prefix_len,
                                          removed_fh_count, p_fh->next_hop_id);
                     }
@@ -221,7 +221,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
                 if (!FIB_IS_FH_VALID_ECMP(p_fh, valid_ecmp_count)) {
                     p_dr_fh->status = FIB_DRFH_STATUS_UNWRITTEN;
                     HAL_RT_LOG_DEBUG("HAL-RT-NDI",
-                            "NH Group Add SKIP!!: VRF %d. Prefix: %s/%d, " "FH: %d, NH handle: %d",
+                            "NH Group Add SKIP!!: VRF %d. Prefix: %s/%d, " "FH: %d, NH handle: %lu",
                             p_fh->vrf_id,
                             FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                             p_dr->prefix_len, p_fh->key.if_index,
@@ -231,7 +231,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
 
                 p_dr_fh->status = FIB_DRFH_STATUS_WRITTEN;
                 HAL_RT_LOG_INFO("HAL-RT-NDI", "NH Group Add VRF %d, Prefix: %s/%d FH-intf:%d IP:%s "
-                                " nh_count: %d, NH handle: %d",
+                                " nh_count: %d, NH handle: %lu",
                                 p_fh->vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                                 p_dr->prefix_len, p_fh->key.if_index,
                                 FIB_IP_ADDR_TO_STR(&(p_fh->key.ip_addr)),
@@ -258,7 +258,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
                             return DN_HAL_ROUTE_E_FAIL;
                         }
                         HAL_RT_LOG_DEBUG("HAL-RT-NDI",
-                                "NH Group: RIF ID 0x%llx!" "Vrf_id: %d.",
+                                "NH Group: RIF ID 0x%lx!" "Vrf_id: %d.",
                                 rif_id, vrf_id);
 
                         memset(&nbr_entry, 0, sizeof(nbr_entry));
@@ -273,7 +273,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
                                 return STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0);
                             }
                             p_fh->next_hop_id = nh_handle;
-                            hal_rt_rif_ref_inc(p_fh->key.if_index);
+                            hal_rt_rif_ref_inc(vrf_id, p_fh->key.if_index);
                         }
                     }
 
@@ -288,7 +288,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
 
                 HAL_RT_LOG_DEBUG("HAL-RT-NDI",
                         "NH Group Add to NHLIST: VRF %d. Prefix: %s/%d, "
-                        "FH: %d, nh_id[%d]: %d",
+                        "FH: %d, nh_id[%d]: %lu",
                         p_fh->vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                         p_dr->prefix_len, p_fh->key.if_index, valid_ecmp_count,
                         nh_handle);
@@ -319,7 +319,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
 
         HAL_RT_LOG_INFO ("HAL-RT-NDI",
                 "OLD NH Group: VRF %d. " "Prefix: %s/%d, num_fh: %d, valid_ecmp_count=%d, removed_fh_count=%d "
-                "OLD NH Group ID =%d \n",
+                "OLD NH Group ID =%ld \n",
                 vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                 p_dr->prefix_len, p_dr->num_fh, valid_ecmp_count, removed_fh_count,
                 p_dr->nh_handle);
@@ -332,7 +332,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
             route_entry.action = NDI_ROUTE_PACKET_ACTION_TRAPCPU;
             HAL_RT_LOG_DEBUG("HAL-RT-NDI",
                     "NH Group: VRF %d. " "Prefix: %s/%d, num_fh: %d, valid_ecmp_count=%d, "
-                    "NH Group ID =%d  ERROR!!!!!ERROR!!!! \n",
+                    "NH Group ID =%ld ERROR!!!!!ERROR!!!! \n",
                     vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                     p_dr->prefix_len, p_dr->num_fh, valid_ecmp_count,
                     p_dr->nh_handle);
@@ -347,7 +347,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
                     &nh_group_handle, &is_ecmp_table_full, &removed_nh_group_entry);
             if (rc != STD_ERR_OK) {
                 HAL_RT_LOG_ERR("HAL-RT-NDI",
-                        "ECMP Group: Create Group ID failed. VRF %d. Prefix: " "%s/%d, Unit: %d, Err: %d, %s %d",
+                        "ECMP Group: Create Group ID failed. VRF %d. Prefix: " "%s/%d, Unit: %d, Err: %d, %s",
                         vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                         p_dr->prefix_len, npu_id, rc,
                         is_ecmp_table_full ?
@@ -356,7 +356,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
 
             } else {
                 HAL_RT_LOG_DEBUG("HAL-RT-NDI",
-                        "ECMP Group: Using Group ID: %d. VRF %d. Prefix: " "%s/%d,Unit: %d, Err: %d",
+                        "ECMP Group: Using Group ID: %lu. VRF %d. Prefix: " "%s/%d,Unit: %d, Err: %d",
                         nh_group_handle, vrf_id,
                         FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                         p_dr->prefix_len, npu_id, rc);
@@ -406,7 +406,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
         }
 
         HAL_RT_LOG_INFO("HAL-RT-NDI",
-                "MP: Multi-path Route Add " "contents: VRF %d, Prefix: %s/%d, NH_handle=%d, action=%d, "
+                "MP: Multi-path Route Add " "contents: VRF %d, Prefix: %s/%d, NH_handle=%lu, action=%d, "
                 "num_fh=%d, valid_ecmp_count=%d, Unit: %d",
                 vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                 p_dr->prefix_len, nh_group_handle, route_entry.action,
@@ -432,7 +432,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
                 p_dr->nh_handle = nh_group_handle;
                 HAL_RT_LOG_INFO("HAL-RT-NDI",
                                 " MP: ECMP Route Add (%s): Successful. VRF %d. " "Prefix: %s/%d, num_fh: %d, "
-                                "nh_group_id %d \n",(is_ecmp_table_full)? "non-ECMP due to FULL":"",
+                                "nh_group_id %lu \n",(is_ecmp_table_full)? "non-ECMP due to FULL":"",
                                 vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                                 p_dr->prefix_len, p_dr->num_fh, p_dr->nh_handle);
                 p_dr->nh_handle = route_entry.nh_handle;
@@ -474,7 +474,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
                 if (rc != STD_ERR_OK) {
                     HAL_RT_LOG_ERR("HAL-RT-NDI",
                                    "MP: ECMP Route Update: Failed. Attribute Group Nexthop ID set failed."
-                                   "Prefix: %s/%d Unit: %d, Err: %d, old gid %d, new gid to set %d",
+                                   "Prefix: %s/%d Unit: %d, Err: %d, old gid %lu, new gid to set %lu",
                                    FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                                    p_dr->prefix_len, npu_id, rc, p_dr->nh_handle,
                                    route_entry.nh_handle);
@@ -484,7 +484,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
             }
             HAL_RT_LOG_INFO("HAL-RT-NDI",
                             "MP: ECMP Route Update:  Successful, VRF %d, Prefix: %s/%d - "
-                            "old gid %d, new gid %d %s",
+                            "old gid %lu, new gid %lu %s",
                             vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                             p_dr->prefix_len, p_dr->nh_handle, nh_group_handle,
                             (ecmp_handle_created && p_dr->ofh_cnt <= 1) ?
@@ -502,7 +502,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
                  */
                 HAL_RT_LOG_INFO("HAL-RT-NDI",
                                 "NH Group delete (changing from ECMP to Non-ECMP). Deleting old mp_obj Node. "
-                                " VRF %d. Prefix: %s/%d, num_fh: %d, " "nh_group_id =%d \n",
+                                " VRF %d. Prefix: %s/%d, num_fh: %d, " "nh_group_id =%lu \n",
                                 p_dr->vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                                 p_dr->prefix_len, p_dr->num_fh, p_dr->nh_handle);
 
@@ -510,7 +510,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
 
                 if (rc != STD_ERR_OK) {
                     HAL_RT_LOG_ERR("HAL-RT-MP",
-                                   "NH Group:Failed to delete Route, group:%d. " "Vrf_id: %d, Unit: %d. Err: %d ",
+                                   "NH Group:Failed to delete Route, group:%lu. " "Vrf_id: %d, Unit: %d. Err: %d ",
                                    p_dr->nh_handle, vrf_id, npu_id, rc);
                 }
             }
@@ -528,7 +528,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
              */
             HAL_RT_LOG_DEBUG("HAL-RT-NDI",
                     "MP: ECMP Route already programmed as %s! Prefix: %s/%d "
-                    "- old gid %d, new gid %d!",
+                    "- old gid %lu, new gid %lu!",
                     is_ecmp_table_full ? "Non-ECMP as Group ECMP table is full" : "ECMP",
                     FIB_IP_ADDR_TO_STR (&p_dr->key.prefix), p_dr->prefix_len,
                     p_dr->nh_handle, nh_group_handle);
@@ -596,7 +596,7 @@ dn_hal_route_err hal_fib_ecmp_route_del(uint32_t vrf_id, t_fib_dr *p_dr) {
         rc = ndi_route_delete(&route_entry);
         if (rc != STD_ERR_OK) {
             HAL_RT_LOG_ERR("HAL-RT-NDI",
-                           "MP:Multi-path Route Delete failed. VRF %d, " "Prefix: %s/%d, Unit: %d, Err: %",
+                           "MP:Multi-path Route Delete failed. VRF %d, " "Prefix: %s/%d, Unit: %d, Err: %d",
                            vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                            p_dr->prefix_len, npu_id, rc);
             error_occured = true;
@@ -614,14 +614,14 @@ dn_hal_route_err hal_fib_ecmp_route_del(uint32_t vrf_id, t_fib_dr *p_dr) {
          * in SAI (decrement ref cnt) and if group rf cnt is 0 delete from HW)
          */
         HAL_RT_LOG_INFO("HAL-RT-NDI",
-                        "NH Group delete: VRF %d. Prefix: %s/%d, num_fh: %d, " "nh_group_id =%d \n",
+                        "NH Group delete: VRF %d. Prefix: %s/%d, num_fh: %d, " "nh_group_id =%lu \n",
                         vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                         p_dr->prefix_len, p_dr->num_fh, p_dr->nh_handle);
         rc = hal_rt_delete_ecmp_group(p_dr, &route_entry, p_dr->nh_handle, true);
 
         if (rc != STD_ERR_OK) {
             HAL_RT_LOG_ERR("HAL-RT-MP",
-                           "NH Group:Failed to delete Route, group:%d. " "Vrf_id: %d, Unit: %d. Err: %d ",
+                           "NH Group:Failed to delete Route, group:%lu. " "Vrf_id: %d, Unit: %d. Err: %d ",
                            p_dr->nh_handle, vrf_id, npu_id, rc);
             error_occured = true;
         }

--- a/src/hal_rt_mpath_grp.c
+++ b/src/hal_rt_mpath_grp.c
@@ -379,7 +379,7 @@ t_fib_mp_obj *hal_rt_check_and_reuse_mp_obj (t_fib_dr *p_dr,
             HAL_RT_LOG_INFO ("HAL-RT-MP",
                              "ECMP NH removal scenario. Found MP obj for OLD NH list. "
                              "VRF %d Prefix: %s/%d "
-                             "mp nh_count:%d, mp GID:%d, ref_cnt:%d",
+                             "mp nh_count:%d, mp GID:%lu, ref_cnt:%d",
                              p_dr->vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix), p_dr->prefix_len,
                              p_mp_obj->ecmp_count, p_mp_obj->sai_ecmp_gid, p_mp_obj->ref_count);
 
@@ -395,7 +395,7 @@ t_fib_mp_obj *hal_rt_check_and_reuse_mp_obj (t_fib_dr *p_dr,
                 {
                     HAL_RT_LOG_ERR ("HAL-RT-MP",
                                     "Failed to update Multipath mp_obj Node for NH removal. "
-                                    "Unit:%d, Vrf_id:%d, Prefix: %s/%d mp GID:%d\n",
+                                    "Unit:%d, Vrf_id:%d, Prefix: %s/%d mp GID:%lu\n",
                                     unit, p_dr->vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
                                     p_dr->prefix_len, p_mp_obj->sai_ecmp_gid);
                     /* failed to update MP group. So switch to regular flow and create a new group */
@@ -407,7 +407,7 @@ t_fib_mp_obj *hal_rt_check_and_reuse_mp_obj (t_fib_dr *p_dr,
                     HAL_RT_LOG_INFO ("HAL-RT-MP",
                                      "ECMP NH removal scenario. Removed NH's from current MP obj. "
                                      "VRF %d Prefix: %s/%d "
-                                     "removed nh_count:%d, mp GID:%d, ref_cnt:%d",
+                                     "removed nh_count:%d, mp GID:%lu, ref_cnt:%d",
                                      p_dr->vrf_id, FIB_IP_ADDR_TO_STR (&p_dr->key.prefix), p_dr->prefix_len,
                                      removed_nh_group_entry->nhop_count, p_mp_obj->sai_ecmp_gid, p_mp_obj->ref_count);
                 }
@@ -440,7 +440,7 @@ t_std_error hal_rt_delete_ecmp_group(t_fib_dr *p_dr, ndi_route_t  *entry,
     if (p_mp_obj == NULL)
     {
         HAL_RT_LOG_DEBUG("HAL-RT-NDI",
-                   "Multipath Object is NULL. Vrf_id: %d, Unit: "
+                   "Multipath Object is NULL. Vrf_id: %lu, Unit: "
                    "%d.\n", entry->vrf_id, unit);
         return STD_ERR_OK;
     }
@@ -455,7 +455,7 @@ t_std_error hal_rt_delete_ecmp_group(t_fib_dr *p_dr, ndi_route_t  *entry,
         if (rc != STD_ERR_OK) {
             HAL_RT_LOG_DEBUG("HAL-RT-MP",
                     "NH Group: Failed to delete ECMP group:%d mp_obj_id:%d "
-                    "Vrf_id: %d, Unit: %d. Err: %d ", (int) p_dr->nh_handle,
+                    "Vrf_id: %lu, Unit: %d. Err: %d ", (int) p_dr->nh_handle,
                     (int) p_mp_obj->sai_ecmp_gid, entry->vrf_id, entry->npu_id, rc);
 
             return (STD_ERR(ROUTE, FAIL, 0));

--- a/src/hal_rt_mpath_util.c
+++ b/src/hal_rt_mpath_util.c
@@ -243,7 +243,7 @@ t_fib_mp_obj *hal_rt_fib_create_mp_obj (t_fib_dr *p_dr, ndi_nh_group_t *entry,
 
 
         HAL_RT_LOG_DEBUG ("HAL-RT-NDI",
-                "NH Group: %s New Group ID: %d Old GID=%d. VRF %d. Prefix: "
+                "NH Group: %s New Group ID: %lu Old GID=%d. VRF %d. Prefix: "
                 "%s/%d,Unit: %d, Err: %d", is_with_id ? "Updated":"Created",
                         nh_group_handle, sai_ecmp_gid, p_dr->vrf_id,
                 FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
@@ -307,7 +307,7 @@ t_std_error hal_rt_fib_remove_members_from_mp_obj (t_fib_dr *p_dr, t_fib_mp_obj 
 
     if (rc != STD_ERR_OK) {
         HAL_RT_LOG_ERR ("HAL-RT-NDI",
-                "NH Group member remove failed nhop_count:%d. MP GID:%d VRF %d. Prefix: "
+                "NH Group member remove failed nhop_count:%d. MP GID:%lu VRF %d. Prefix: "
                 "%s/%d, Unit: %d, Err: %d",
                 removed_nh_group_entry->nhop_count, sai_ecmp_gid, p_dr->vrf_id,
                 FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
@@ -333,7 +333,7 @@ t_std_error hal_rt_fib_remove_members_from_mp_obj (t_fib_dr *p_dr, t_fib_mp_obj 
 
     if (STD_IS_ERR(rc))
     {
-        HAL_RT_LOG_ERR ("HAL_RT-MPATH", "Remove members from MP Object:%d "
+        HAL_RT_LOG_ERR ("HAL_RT-MPATH", "Remove members from MP Object:%lu "
                         "Failed to insert p_mp_obj in Tree.\n", sai_ecmp_gid);
 
 //@@TODO - check for failure hanlding and how p_mp_obj state will be
@@ -423,7 +423,7 @@ t_std_error hal_rt_fib_check_and_delete_old_groupid(t_fib_dr *p_dr, npu_id_t  un
         rc = ndi_route_next_hop_group_delete (unit,  p_dr->onh_handle);
         if (rc != STD_ERR_OK) {
             HAL_RT_LOG_ERR ("HAL-RT-NDI",
-                              "NH Group: Old Group ID delete failed. gid %d VRF %d. Prefix: "
+                            "NH Group: Old Group ID delete failed. gid %lu VRF %d. Prefix: "
                               "%s/%d, Unit: %d, Err: %d",
                               p_dr->onh_handle,  p_dr->vrf_id,
                               FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
@@ -431,7 +431,7 @@ t_std_error hal_rt_fib_check_and_delete_old_groupid(t_fib_dr *p_dr, npu_id_t  un
             return (STD_ERR(ROUTE, FAIL, 0));
         } else {
             HAL_RT_LOG_DEBUG ("HAL-RT-NDI",
-                              "NH Group: Old Group ID delete SUCCESS. gid %d VRF %d. Prefix: "
+                              "NH Group: Old Group ID delete SUCCESS. gid %lu VRF %d. Prefix: "
                               "%s/%d, Unit: %d, Err: %d",
                               p_dr->onh_handle,  p_dr->vrf_id,
                               FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),

--- a/src/hal_rt_offload.cpp
+++ b/src/hal_rt_offload.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*!
+ * \file   hal_rt_offload.c
+ * \brief  Hal Routing Offload functionality
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "hal_rt_main.h"
+#include "hal_rt_util.h"
+#include "hal_rt_debug.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#include <cstring>
+#include <cstdio>
+#include "event_log.h"
+#include "hal_if_mapping.h"
+#include "nas_if_utils.h"
+#include <unordered_map>
+#include <memory>
+#include <deque>
+#include <utility>
+#include <mutex>
+#include <sstream>
+#include <condition_variable>
+#include <algorithm>
+#include "std_utils.h"
+
+#include "cps_api_object_category.h"
+#include "cps_api_route.h"
+#include "cps_api_operation.h"
+#include "cps_api_object_tools.h"
+#include "cps_api_operation_tools.h"
+#include "cps_class_map.h"
+#include "dell-base-neighbor.h"
+
+#include "std_utils.h"
+#include "std_rw_lock.h"
+
+using fib_offload_msg_uptr_t = std::unique_ptr<t_fib_offload_msg>;
+static auto &hal_rt_offload_msg_list = *new std::deque<fib_offload_msg_uptr_t>;
+/* stats counter for hal_rt_offload_msg_list queue on per msg type basis */
+static auto hal_rt_offload_msg_list_stats = new std::unordered_map<uint32_t,uint32_t> {
+            { FIB_OFFLOAD_MSG_TYPE_NEIGH_FLUSH, 0 },
+};
+
+uint_t hal_rt_offload_msg_peak_cnt = 0;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+std::mutex m_offload_mtx;
+std::condition_variable  m_offload_data;
+
+fib_offload_msg_uptr_t nas_rt_read_offload_msg () {
+    std::unique_lock<std::mutex> l {m_offload_mtx};
+    if (hal_rt_offload_msg_list.empty()) {
+        m_offload_data.wait (l, []{return !hal_rt_offload_msg_list.empty();});
+    }
+    auto p_offload_msg = std::move(hal_rt_offload_msg_list.front());
+    hal_rt_offload_msg_list.pop_front();
+
+    auto it = hal_rt_offload_msg_list_stats->find(p_offload_msg->type);
+    if (it != hal_rt_offload_msg_list_stats->end())
+        it->second--;
+    return p_offload_msg;
+}
+
+int fib_offload_msg_main(void) {
+    /* Process the offload messages from queue */
+    for(;;) {
+        fib_offload_msg_uptr_t p_offload_msg_uptr = nas_rt_read_offload_msg();
+        if (!p_offload_msg_uptr)
+            continue;
+        auto p_offload_msg = p_offload_msg_uptr.get();
+        switch(p_offload_msg->type) {
+            case FIB_OFFLOAD_MSG_TYPE_NEIGH_FLUSH:
+                HAL_RT_LOG_DEBUG("HAL-RT-OFFLOAD-MSG-THREAD",
+                                 "Neigh flush msg processing type:%d", p_offload_msg->type);
+                hal_rt_process_neigh_flush_offload_msg (&p_offload_msg->neigh_flush_msg);
+                break;
+            default:
+                break;
+        }
+    }
+    return true;
+}
+
+
+int nas_rt_process_offload_msg(t_fib_offload_msg *p_offload_msg) {
+    bool hal_rt_offload_msg_thr_wakeup = false;
+    if (p_offload_msg) {
+        std::lock_guard<std::mutex> l {m_offload_mtx};
+        hal_rt_offload_msg_thr_wakeup = hal_rt_offload_msg_list.empty();
+        hal_rt_offload_msg_list.emplace_back(p_offload_msg);
+
+        auto it = hal_rt_offload_msg_list_stats->find(p_offload_msg->type);
+        if (it != hal_rt_offload_msg_list_stats->end())
+            it->second++;
+
+        if (hal_rt_offload_msg_peak_cnt < hal_rt_offload_msg_list.size())
+            hal_rt_offload_msg_peak_cnt = hal_rt_offload_msg_list.size();
+    }
+    if (hal_rt_offload_msg_thr_wakeup) m_offload_data.notify_one ();
+    return true;
+}
+
+
+t_fib_offload_msg *hal_rt_alloc_offload_msg() {
+    t_fib_offload_msg *p_offload_msg = new (std::nothrow) t_fib_offload_msg;
+    return p_offload_msg;
+}
+
+std::string hal_rt_offload_queue_stats ()
+{
+    std::lock_guard<std::mutex> l {m_offload_mtx};
+    std::stringstream ss;
+    ss << "Current:" << hal_rt_offload_msg_list.size() << " Peak:" << hal_rt_offload_msg_peak_cnt;
+    return ss.str();
+}
+
+std::string hal_rt_offload_queue_msg_type_stats ()
+{
+    std::lock_guard<std::mutex> l {m_offload_mtx};
+    std::stringstream ss;
+    ss << "Offload Msg Type Stats";
+    for (auto it = hal_rt_offload_msg_list_stats->begin(); it != hal_rt_offload_msg_list_stats->end(); ++it)
+        ss << "MsgType:" << it->first << " Msg Count:" << it->second;
+    return ss.str();
+}
+
+bool hal_rt_process_neigh_flush_offload_msg(t_fib_offload_msg_neigh_flush *p_flush_msg) {
+    char vrf_name[MAX_LEN_VRF_NAME];
+
+    cps_api_object_guard obj_g (cps_api_obj_tool_create(cps_api_qualifier_TARGET,
+                                 BASE_NEIGHBOR_FLUSH_OBJ, false));
+
+    if (obj_g.get() == nullptr)
+    {
+        HAL_RT_LOG_ERR ("HAL-RT-OFF", " CPS object create failed ");
+        return false;
+    }
+
+    memset (vrf_name, 0, MAX_LEN_VRF_NAME);
+    if (!hal_rt_get_vrf_name(p_flush_msg->vrf_id, vrf_name))
+    {
+        HAL_RT_LOG_ERR ("HAL-RT-OFF", " Invalid VRF id:%d", p_flush_msg->vrf_id);
+        return false;
+    }
+
+    cps_api_object_attr_add(obj_g.get(), BASE_NEIGHBOR_FLUSH_INPUT_VRF_NAME, vrf_name,
+                            strlen(vrf_name)+1);
+    cps_api_object_attr_add_u32(obj_g.get(),BASE_NEIGHBOR_FLUSH_INPUT_AF, p_flush_msg->prefix.af_index);
+
+    size_t addr_len = (p_flush_msg->prefix.af_index == AF_INET) ? HAL_INET4_LEN:HAL_INET6_LEN;
+    cps_api_attr_id_t ids[1] = {BASE_NEIGHBOR_FLUSH_INPUT_IP};
+    cps_api_object_e_add(obj_g.get(), ids, 1, cps_api_object_ATTR_T_BIN,
+                         p_flush_msg->prefix.u.v6_addr, addr_len);
+
+    cps_api_object_attr_add_u32(obj_g.get(),BASE_NEIGHBOR_FLUSH_INPUT_PREFIX_LEN, p_flush_msg->prefix_len);
+
+    if (p_flush_msg->is_neigh_flush_with_intf) {
+        interface_ctrl_t   intf_ctrl;
+        memset(&intf_ctrl, 0, sizeof(intf_ctrl));
+
+        intf_ctrl.q_type = HAL_INTF_INFO_FROM_IF;
+        intf_ctrl.if_index = p_flush_msg->if_index;
+
+        if (dn_hal_get_interface_info(&intf_ctrl) == STD_ERR_OK) {
+            cps_api_object_attr_add(obj_g.get(), BASE_NEIGHBOR_FLUSH_INPUT_IFNAME, intf_ctrl.if_name,
+                                    strlen(intf_ctrl.if_name)+1);
+            HAL_RT_LOG_INFO ("HAL-RT-OFF", " Processing Neigh flush message for "
+                             "vrf_id: %d, prefix: %s, prefix_len: %d "
+                             "flush_with_intf: %s, if_name: %s(%d)", p_flush_msg->vrf_id,
+                             FIB_IP_ADDR_TO_STR (&p_flush_msg->prefix), p_flush_msg->prefix_len,
+                             (p_flush_msg->is_neigh_flush_with_intf ? "true":"false"),
+                             intf_ctrl.if_name, p_flush_msg->if_index);
+
+            if((cps_api_commit_one(cps_api_oper_ACTION, obj_g.get(), 1,0)) != cps_api_ret_code_OK){
+                HAL_RT_LOG_ERR ("HAL-RT-OFF", "CPS commit failed ");
+                return false;
+            }
+            HAL_RT_LOG_INFO ("HAL-RT-OFF", "IP neigh flush CPS commit success");
+        }
+    } else {
+
+        HAL_RT_LOG_INFO ("HAL-RT-OFF", " Processing Neigh flush message for "
+                         "vrf_id: %d, prefix: %s, prefix_len: %d "
+                         "flush_with_intf: %s, if_name: %s(%d)", p_flush_msg->vrf_id,
+                         FIB_IP_ADDR_TO_STR (&p_flush_msg->prefix), p_flush_msg->prefix_len,
+                         (p_flush_msg->is_neigh_flush_with_intf ? "true":"false"),
+                         "N/A", p_flush_msg->if_index);
+        if((cps_api_commit_one(cps_api_oper_ACTION, obj_g.get(), 1,0)) != cps_api_ret_code_OK){
+            HAL_RT_LOG_ERR ("HAL-RT-OFF", "CPS commit failed ");
+            return false;
+        }
+        HAL_RT_LOG_INFO ("HAL-RT-OFF", "IP neigh flush CPS commit success");
+    }
+
+    return true;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/src/nas_rt_mac.cpp
+++ b/src/nas_rt_mac.cpp
@@ -97,7 +97,7 @@ bool nas_rt_peer_mac_db_add (nas_rt_peer_mac_config_t* mac_info)
     nas_rt_mac_uptr_t mac_uptr (new nas_rt_peer_mac_config_t (*mac_info));
     nas_rt_db_add_peer_mac_list (mac_uptr);
 
-    HAL_RT_LOG_INFO("HAL-RT", "Vrf:%d if-name:%s peer-mac:%s vrf obj:0x%x rif obj:0x%x "
+    HAL_RT_LOG_INFO("HAL-RT", "Vrf:%d if-name:%s peer-mac:%s vrf obj:0x%lx rif obj:0x%lx "
                     "added successfully", mac_info->vrf_id, mac_info->if_name,
                     hal_rt_mac_to_str(&mac_info->mac, p_buf, MAC_STR_LEN),
                     mac_info->vrf_obj_id, mac_info->rif_obj_id);
@@ -167,7 +167,6 @@ t_std_error nas_route_get_all_peer_routing_config(cps_api_object_list_t list){
     for (vrf_id = FIB_MIN_VRF; vrf_id < FIB_MAX_VRF; vrf_id ++) {
         p_vrf = hal_rt_access_fib_vrf(vrf_id);
         if (p_vrf == NULL) {
-            HAL_RT_LOG_ERR("HAL-RT", "Vrf node NULL. Vrf_id: %d", vrf_id);
             continue;
         }
 
@@ -204,14 +203,14 @@ t_std_error nas_route_delete_vrf_peer_mac_config(uint32_t vrf_id) {
     char p_buf[MAC_STR_LEN];
     for(auto& x: mac_list){
         nas_rt_peer_mac_config_t *ptr = x.second.get();
-        HAL_RT_LOG_DEBUG("HAL-RT", "Vrf:%d if_name:%s peer-mac:%s vrf:0x%x rif:0x%x info",
+        HAL_RT_LOG_DEBUG("HAL-RT", "Vrf:%d if_name:%s peer-mac:%s vrf:0x%lx rif:0x%lx info",
                          vrf_id, ptr->if_name,
                          hal_rt_mac_to_str(&ptr->mac, p_buf, MAC_STR_LEN),
                          ptr->vrf_obj_id, ptr->rif_obj_id);
         if (ptr->vrf_obj_id) {
             /* Remove peer VLT MAC information */
             if ((rc = ndi_route_vr_delete(0, ptr->vrf_obj_id))!= STD_ERR_OK) {
-                HAL_RT_LOG_ERR("HAL-RT", "Vrf:%d if_name:%s peer-mac:%s obj-id:0x%x deletion failed!",
+                HAL_RT_LOG_ERR("HAL-RT", "Vrf:%d if_name:%s peer-mac:%s obj-id:0x%lx deletion failed!",
                                vrf_id, ptr->if_name,
                                hal_rt_mac_to_str(&ptr->mac, p_buf, MAC_STR_LEN),
                                ptr->vrf_obj_id);
@@ -219,7 +218,7 @@ t_std_error nas_route_delete_vrf_peer_mac_config(uint32_t vrf_id) {
             }
         } else if (ptr->rif_obj_id) {
             if (ndi_rif_delete(0, ptr->rif_obj_id) != STD_ERR_OK) {
-                HAL_RT_LOG_ERR("HAL-RT", "Vrf:%d if_name:%s peer-mac:%s obj-id:0x%x deletion failed!",
+                HAL_RT_LOG_ERR("HAL-RT", "Vrf:%d if_name:%s peer-mac:%s obj-id:0x%lx deletion failed!",
                                vrf_id, ptr->if_name,
                                hal_rt_mac_to_str(&ptr->mac, p_buf, MAC_STR_LEN),
                                ptr->rif_obj_id);

--- a/src/nas_rt_virt_routing.cpp
+++ b/src/nas_rt_virt_routing.cpp
@@ -1,0 +1,328 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*!
+ * \file   nas_rt_virt_routing.cpp
+ * \brief  NAS virtual routing handling
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "hal_rt_main.h"
+#include "hal_rt_util.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#include "event_log.h"
+#include <unordered_map>
+#include <iostream>
+#include <memory>
+#include <string>
+
+inline std::string nas_rt_make_ip_string (const hal_ip_addr_t & ip_addr)
+{
+    char str [INET6_ADDRSTRLEN] = {0};
+    return {std_ip_to_string (&ip_addr, str, INET6_ADDRSTRLEN)};
+}
+
+static std_mutex_lock_create_static_init_rec(nas_rt_ip_mutex);
+using nas_rt_ip_uptr_t = std::unique_ptr<nas_rt_virtual_routing_ip_config_t>;
+
+/* ifname based map of type nas_rt_virtual_routing_ip_config_t */
+using nas_rt_if_ip_addr_list_t = std::unordered_map <std::string, nas_rt_ip_uptr_t>;
+/* Vrf, Peer ip based map */
+using nas_rt_ip_addr_list_t = std::unordered_map <std::string, nas_rt_if_ip_addr_list_t>;
+static auto &virtual_routing_ip_list = *new std::unordered_map <hal_vrf_id_t, nas_rt_ip_addr_list_t>;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+static bool nas_rt_db_add_virtual_routing_ip_list(nas_rt_ip_uptr_t &ip_uptr)
+{
+    std::string if_name_str = ip_uptr->if_name;
+    std::string ip_str = nas_rt_make_ip_string(ip_uptr->ip_addr);
+    virtual_routing_ip_list[ip_uptr->vrf_id][ip_str][if_name_str] = std::move (ip_uptr);
+    return true;
+}
+
+uint32_t nas_rt_virtual_routing_ip_list_size (const nas_rt_virtual_routing_ip_config_t * req)
+{
+    std_mutex_simple_lock_guard l(&nas_rt_ip_mutex);
+
+    auto vrf_it = virtual_routing_ip_list.find(req->vrf_id);
+    if(vrf_it == virtual_routing_ip_list.end()) return 0;
+
+    auto& ip_list = vrf_it->second;
+    std::string ip_str = nas_rt_make_ip_string(req->ip_addr);
+    auto ip_it = ip_list.find(ip_str);
+    if(ip_it == ip_list.end()) return 0;
+
+    auto& if_ip_list = ip_it->second;
+    return if_ip_list.size();
+}
+
+bool nas_rt_virtual_routing_ip_get (const nas_rt_virtual_routing_ip_config_t * req,
+                                    nas_rt_virtual_routing_ip_config_t* reply_p)
+{
+    std_mutex_simple_lock_guard l(&nas_rt_ip_mutex);
+
+    auto vrf_it = virtual_routing_ip_list.find(req->vrf_id);
+    if(vrf_it == virtual_routing_ip_list.end()) return false;
+
+    auto& ip_list = vrf_it->second;
+    std::string ip_str = nas_rt_make_ip_string(req->ip_addr);
+    auto ip_it = ip_list.find(ip_str);
+    if(ip_it == ip_list.end()) return false;
+
+    auto& if_ip_list = ip_it->second;
+    std::string if_name_str = req->if_name;
+    auto if_name_it = if_ip_list.find(if_name_str);
+    if(if_name_it == if_ip_list.end()) return false;
+
+    if (reply_p != nullptr) *reply_p = *(if_name_it->second);
+    return true;
+}
+
+bool nas_rt_virtual_routing_ip_db_add (nas_rt_virtual_routing_ip_config_t * ip_info)
+{
+    std_mutex_simple_lock_guard l(&nas_rt_ip_mutex);
+
+    nas_rt_virtual_routing_ip_config_t old_ip;
+    if (nas_rt_virtual_routing_ip_get (ip_info, &old_ip)) {
+        HAL_RT_LOG_ERR("HAL-RT", "Virtual routing Vrf:%d if-name:%s IP:%s already exists",
+                       ip_info->vrf_id, ip_info->if_name,
+                       FIB_IP_ADDR_TO_STR(&ip_info->ip_addr));
+        return false;
+    }
+
+    nas_rt_ip_uptr_t ip_uptr (new nas_rt_virtual_routing_ip_config_t (*ip_info));
+    nas_rt_db_add_virtual_routing_ip_list (ip_uptr);
+
+    HAL_RT_LOG_DEBUG ("HAL-RT", "Virtual routing Vrf:%d if-name:%s IP:%s  "
+                      "added successfully", ip_info->vrf_id, ip_info->if_name,
+                      FIB_IP_ADDR_TO_STR(&ip_info->ip_addr));
+    return true;
+}
+
+static bool nas_rt_virtual_routing_ip_db_del_ip_list(const nas_rt_virtual_routing_ip_config_t & ip_info)
+{
+    auto vrf_it = virtual_routing_ip_list.find(ip_info.vrf_id);
+    if(vrf_it == virtual_routing_ip_list.end()) return false;
+    auto &ip_list = vrf_it->second;
+
+
+    std::string ip_str = nas_rt_make_ip_string(ip_info.ip_addr);
+    auto ip_it = ip_list.find(ip_str);
+    if(ip_it == ip_list.end()) return false;
+
+    auto& if_ip_list = ip_it->second;
+
+    std::string if_name_str = ip_info.if_name;
+    auto if_name_it = if_ip_list.find(if_name_str);
+    if(if_name_it == if_ip_list.end()) return false;
+
+    auto erased = if_ip_list.erase(if_name_str);
+
+    if (if_ip_list.empty()) {
+        ip_list.erase(ip_str);
+        if (ip_list.empty())
+            virtual_routing_ip_list.erase(ip_info.vrf_id);
+    }
+
+    return (erased > 0);
+}
+
+bool nas_rt_virtual_routing_ip_db_del (nas_rt_virtual_routing_ip_config_t * ip_info)
+{
+    std_mutex_simple_lock_guard l(&nas_rt_ip_mutex);
+
+    if (!nas_rt_virtual_routing_ip_db_del_ip_list(*ip_info)) {
+        HAL_RT_LOG_ERR("HAL-RT", "Virtual routing Could not find vrf:%d if-name:%s IP:%s in the list",
+                       ip_info->vrf_id, ip_info->if_name,
+                       FIB_IP_ADDR_TO_STR(&ip_info->ip_addr));
+        return false;
+    }
+
+    return true;
+}
+
+t_std_error nas_route_get_all_virtual_routing_ip_config (cps_api_object_list_t list,
+                                                         bool show_all,
+                                                         nas_rt_virtual_routing_ip_config_t *p_cfg) {
+    t_fib_vrf      *p_vrf = NULL;
+    uint32_t       vrf_id = 0;
+
+    if (show_all) {
+        for (vrf_id = FIB_MIN_VRF; vrf_id < FIB_MAX_VRF; vrf_id ++) {
+            p_vrf = hal_rt_access_fib_vrf(vrf_id);
+            if (p_vrf == NULL) {
+                HAL_RT_LOG_ERR("HAL-RT", "Virtual Routing Vrf node NULL. Vrf_id: %d", vrf_id);
+                continue;
+            }
+
+            std_mutex_simple_lock_guard l(&nas_rt_ip_mutex);
+            auto vrf_it = virtual_routing_ip_list.find(vrf_id);
+            if(vrf_it == virtual_routing_ip_list.end()) return STD_ERR_OK;
+            auto &ip_list = vrf_it->second;
+
+            for(auto& ip_it: ip_list){
+                auto& if_ip_list  = ip_it.second;
+                for(auto& x: if_ip_list){
+                    nas_rt_virtual_routing_ip_config_t *ptr = x.second.get();
+                    cps_api_object_t obj = nas_route_virtual_routing_ip_config_to_cps_object (vrf_id, ptr);
+                    if(obj == NULL)
+                        continue;
+
+                    if (!cps_api_object_list_append(list,obj)) {
+                        cps_api_object_delete(obj);
+                        HAL_RT_LOG_ERR("HAL-RT","Failed to append virtual routing IP object to object list");
+                        return STD_ERR(ROUTE,FAIL,0);
+                    }
+                }
+            }
+        }
+    } else {
+        vrf_id = p_cfg->vrf_id;
+        p_vrf = hal_rt_access_fib_vrf(vrf_id);
+        if (p_vrf == NULL) {
+            return STD_ERR_OK;
+        }
+
+        std_mutex_simple_lock_guard l(&nas_rt_ip_mutex);
+        auto vrf_it = virtual_routing_ip_list.find(vrf_id);
+        if(vrf_it == virtual_routing_ip_list.end()) return STD_ERR_OK;
+        auto &ip_list = vrf_it->second;
+
+
+        std::string ip_str = nas_rt_make_ip_string(p_cfg->ip_addr);
+        auto ip_it = ip_list.find(ip_str);
+        if(ip_it == ip_list.end()) return STD_ERR_OK;
+
+        auto& if_ip_list = ip_it->second;
+        std::string if_name_str = p_cfg->if_name;
+        auto if_name_it = if_ip_list.find(if_name_str);
+        if(if_name_it == if_ip_list.end()) return STD_ERR_OK;
+
+        nas_rt_virtual_routing_ip_config_t *ptr = if_name_it->second.get();
+        cps_api_object_t obj = nas_route_virtual_routing_ip_config_to_cps_object (vrf_id, ptr);
+        if(obj == NULL) return STD_ERR_OK;
+
+        if (!cps_api_object_list_append(list,obj)) {
+            cps_api_object_delete(obj);
+            HAL_RT_LOG_ERR("HAL-RT","Failed to append virtual routing IP object to object list");
+            return STD_ERR(ROUTE,FAIL,0);
+        }
+    }
+
+    return STD_ERR_OK;
+}
+
+t_std_error nas_route_delete_vrf_virtual_routing_ip_config(uint32_t vrf_id) {
+
+    std_mutex_simple_lock_guard l(&nas_rt_ip_mutex);
+
+    auto vrf_it = virtual_routing_ip_list.find(vrf_id);
+    if(vrf_it == virtual_routing_ip_list.end()) return STD_ERR_OK;
+    auto &ip_list = vrf_it->second;
+
+    for(auto& ip_it: ip_list){
+        auto& if_ip_list  = ip_it.second;
+        for(auto& x: if_ip_list){
+            nas_rt_virtual_routing_ip_config_t *ptr = x.second.get();
+
+            HAL_RT_LOG_DEBUG ("HAL-RT", "Virtual routing Vrf:%d if-name:%s IP:%s ",
+                              ptr->vrf_id, ptr->if_name,
+                              FIB_IP_ADDR_TO_STR(&ptr->ip_addr));
+
+            if (_hal_rt_virtual_routing_ip_cfg(ptr, false) != STD_ERR_OK) {
+                HAL_RT_LOG_ERR ("HAL-RT", "Virtual routing cfg del failed. Vrf:%d if-name:%s IP:%s ",
+                                ptr->vrf_id, ptr->if_name,
+                                FIB_IP_ADDR_TO_STR(&ptr->ip_addr));
+            }
+        }
+        if_ip_list.clear();
+    }
+    ip_list.clear();
+    virtual_routing_ip_list.erase(vrf_id);
+
+    return STD_ERR_OK;
+}
+
+void fib_dump_virtual_routing_ip_db_get_all_with_vrf(hal_vrf_id_t vrf_id)
+{
+    std_mutex_simple_lock_guard l(&nas_rt_ip_mutex);
+
+    auto vrf_it = virtual_routing_ip_list.find(vrf_id);
+    if(vrf_it == virtual_routing_ip_list.end()) {
+        std::cout << "VRF list empty" << std::endl;
+        return;
+    }
+    auto &ip_list = vrf_it->second;
+
+    char str [INET6_ADDRSTRLEN] = {0};
+
+    for(auto& ip_it: ip_list){
+        auto& if_ip_list  = ip_it.second;
+        for(auto& x: if_ip_list){
+            nas_rt_virtual_routing_ip_config_t *ptr = x.second.get();
+            std_ip_to_string (&ptr->ip_addr, str, INET6_ADDRSTRLEN);
+            std::cout << "Virtual Routing IP Info VRF:" << ptr->vrf_id <<" IF_NAME:"
+                << ptr->if_name <<" IP:"<< str << std::endl;
+        }
+    }
+    return;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+template <typename LIST_TYPE>
+static void nas_rt_print_virtual_routing_ip_stats (const LIST_TYPE& list)
+{
+    std::cout << "Count: " << list.size() << std::endl;
+    std::cout << "Load factor: " << list.load_factor() << std::endl;
+    std::cout << "Bucket Count: " << list.bucket_count() << std::endl;
+
+    std::unordered_map <size_t, size_t> sizes;
+    for (auto& entry: list) {
+        auto bucket = list.bucket(entry.first);
+        ++sizes[list.bucket_size (bucket)];
+    }
+    uint_t total = 0;
+    for (auto size: sizes) {
+        std::cout << "# Buckets with size " << size.first << ": " << size.second << std::endl;
+        total += size.second;
+    }
+    std::cout << "# Buckets with size 0 " << ": " << list.bucket_count() - total << std::endl;
+}
+
+bool nas_rt_virtual_routing_ip_list_stats (uint_t vrf_id)
+{
+    std_mutex_simple_lock_guard l(&nas_rt_ip_mutex);
+    try {
+        nas_rt_print_virtual_routing_ip_stats (virtual_routing_ip_list.at (vrf_id));
+    } catch (...) {
+        return false;
+    }
+    return true;
+}
+

--- a/src/unit_test/hal_rt_dr_unittest.cpp
+++ b/src/unit_test/hal_rt_dr_unittest.cpp
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * hal_rt_dr_unittest.cpp
+ * UT for hal_rt_dr.c
+ */
+#include "nas_rt_util_unittest.h"
+
+#include <gtest/gtest.h>
+#include <iostream>
+
+static cps_api_return_code_t nas_rt_ut_v4_cfg_add()
+{
+    hal_mac_addr_t hw_addr = {0x00, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    nas_ut_neigh_cfg (1, "100.1.1.11", AF_INET, "br100", &hw_addr);
+    nas_ut_rt_cfg ("default",1, "101.101.101.0", 24, AF_INET, "default", "100.1.1.11", "br100");
+
+    return cps_api_ret_code_OK;
+}
+
+static cps_api_return_code_t nas_rt_ut_v6_cfg_add()
+{
+    hal_mac_addr_t hw_addr = {0x00, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    nas_ut_neigh_cfg (1, "100:1::11", AF_INET6, "br100", &hw_addr);
+    nas_ut_rt_cfg ("default", 1, "101:101::0", 64, AF_INET6,  "default", "100:1::11", "br100");
+
+    return cps_api_ret_code_OK;
+}
+
+static cps_api_return_code_t nas_rt_ut_v4_rt_cfg(bool is_add)
+{
+    nas_ut_rt_cfg ("default", is_add, "101.101.101.0", 24, AF_INET, "default", "100.1.1.11", "br100");
+
+    return cps_api_ret_code_OK;
+}
+
+static cps_api_return_code_t nas_rt_ut_v6_rt_cfg(bool is_add)
+{
+    nas_ut_rt_cfg ("default", is_add, "101:101::0", 64, AF_INET6, "default", "100:1::11", "br100");
+
+    return cps_api_ret_code_OK;
+}
+
+static cps_api_return_code_t nas_rt_ut_v6_rt_nh_cfg (bool is_add)
+{
+    if (is_add)
+    {
+        hal_mac_addr_t hw_addr = {0x00, 0x02, 0x03, 0x04, 0x05, 0x16};
+
+        nas_ut_neigh_cfg (1, "200:1::11", AF_INET6, "br200", &hw_addr);
+        nas_ut_neigh_cfg (1, "201:1::11", AF_INET6, "br201", &hw_addr);
+    }
+    nas_ut_rt_ipv6_nh_cfg (is_add, "101:101::0", 64, AF_INET6, "200:1::11", "br200", "201:1::11", "br201");
+
+    return cps_api_ret_code_OK;
+}
+
+
+static cps_api_return_code_t nas_rt_ut_v4_cfg_del ()
+{
+    hal_mac_addr_t hw_addr = {0x00, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    nas_ut_rt_cfg ("default", 0, "101.101.101.0", 24, AF_INET, "default", "100.1.1.11", "br100");
+    nas_ut_neigh_cfg (0, "100.1.1.11", AF_INET, "br100", &hw_addr);
+    return cps_api_ret_code_OK;
+}
+
+static cps_api_return_code_t nas_rt_ut_v6_cfg_del ()
+{
+    hal_mac_addr_t hw_addr = {0x00, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    nas_ut_rt_cfg ("default", 0, "101:101::0", 64, AF_INET6, "default", "100:1::11", "br100");
+    nas_ut_neigh_cfg (0, "100:1::11", AF_INET6, "br100", &hw_addr);
+
+    return cps_api_ret_code_OK;
+}
+
+
+static cps_api_return_code_t nas_rt_ut_validate_v4_rt_cfg(bool is_add)
+{
+    cps_api_return_code_t rc = nas_ut_validate_rt_cfg ("default", AF_INET, "101.101.101.0", 24, "default", "100.1.1.11", "br100", true);
+
+    return rc;
+}
+
+static cps_api_return_code_t nas_rt_ut_validate_v6_rt_cfg(bool is_add)
+{
+    cps_api_return_code_t rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "101:101::0", 64, "default", "100:1::11", "br100", true);
+
+    return rc;
+
+}
+
+
+TEST(hal_rt_dr_test, hal_rt_dr_ut_dup_rt_1nh_del) {
+    cps_api_return_code_t rc;
+    nas_rt_ut_v4_cfg_add();
+    nas_rt_ut_v6_cfg_add();
+
+    /* wait for few secs after configuration, to make sure NAS-L3 processed those netlink events */
+    sleep (5);
+    //nas_rt_ut_validate_v4_rt_cfg(1);
+    rc = nas_rt_ut_validate_v4_rt_cfg(1);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    //nas_rt_ut_validate_v6_rt_cfg(1);
+    rc = nas_rt_ut_validate_v6_rt_cfg(1);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    /* bring admin down */
+    system("ifconfig br100 down");
+    /* delete the route */
+    nas_rt_ut_v4_rt_cfg(0);
+    nas_rt_ut_v6_rt_cfg(0);
+
+    /* wait for few secs after config delete, to make sure NAS-L3 processed those netlink events */
+    sleep (5);
+
+    /* verify the route is deleted */
+    rc = nas_rt_ut_validate_v4_rt_cfg(0);
+    ASSERT_TRUE(rc != cps_api_ret_code_OK);
+
+    rc = nas_rt_ut_validate_v6_rt_cfg(0);
+    ASSERT_TRUE(rc != cps_api_ret_code_OK);
+
+
+    /* clean up */
+    nas_rt_ut_v4_cfg_del();
+    nas_rt_ut_v6_cfg_del();
+    system("ifconfig br100 down");
+}
+
+TEST(hal_rt_dr_test, hal_rt_dr_ut_dup_rt_2nh_del) {
+    cps_api_return_code_t rc;
+    system("ifconfig br100 up");
+    system("ip addr add 100.1.1.2/24 dev br100");
+    system("ip addr add  100:1::1/64 dev br100");
+    nas_rt_ut_v4_cfg_add();
+    nas_rt_ut_v6_cfg_add();
+
+    /* add route nh */
+    //@@TODO - to call route replace with all nh's including new nh for IPv4
+    nas_rt_ut_v6_rt_nh_cfg(1);
+
+    /* wait for few secs after configuration, to make sure NAS-L3 processed those netlink events */
+    sleep (5);
+    rc = nas_rt_ut_validate_v4_rt_cfg(1);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    rc = nas_rt_ut_validate_v6_rt_cfg(1);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    /* bring admin down */
+    system("ifconfig br200 down");
+    system("ifconfig br201 down");
+    /* delete the route nh */
+    //@@TODO - to call route replace with remaining nh's excluding deleted nh for IPv4
+    nas_rt_ut_v6_rt_nh_cfg(0);
+
+    /* wait for few secs after config delete, to make sure NAS-L3 processed those netlink events */
+    sleep (5);
+
+    /* verify the route is still present */
+    rc = nas_rt_ut_validate_v4_rt_cfg(1);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    rc = nas_rt_ut_validate_v6_rt_cfg(1);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    ///* clean up */
+    nas_rt_ut_v4_cfg_del();
+    nas_rt_ut_v6_cfg_del();
+}
+
+TEST(hal_rt_dr_test, hal_rt_dr_check_full_addr) {
+    cps_api_return_code_t rc = nas_ut_validate_rt_cfg ("default", AF_INET, "100.1.1.2", 32, "default",
+                                                       NULL, NULL, false);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+}
+
+TEST(hal_rt_dr_test, hal_rt_dr_check_loopback_addr_in_hw) {
+    system("ip link add lo1 type dummy");
+    system("ip addr add 50.1.1.1/32 dev lo1");
+    system("ip -6 addr add 5111::1/128 dev lo1");
+    sleep(5);
+    cps_api_return_code_t rc = nas_ut_validate_rt_cfg ("default", AF_INET, "50.1.1.1", 32, "default",
+                                                       NULL, NULL, true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "5111::1", 128, "default", NULL, NULL, true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    system("ip link del lo1");
+    sleep(5);
+    /* Verify that the route entries are not present in the NPU */
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "50.1.1.1", 32, "default",
+                                 NULL, NULL, true);
+    ASSERT_TRUE(rc != cps_api_ret_code_OK);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "5111::1", 128, "default", NULL, NULL, true);
+    ASSERT_TRUE(rc != cps_api_ret_code_OK);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+
+  /* configure the test pre-requisite */
+  printf("___________________________________________\n");
+  system("ip address add 6.6.6.1/24  dev e101-005-0");
+  system("ifconfig e101-005-0");
+
+  /* Incase of premium package, all the ports are part of default bridge,
+   * remove it from the bridge to operate as the router intf. */
+  system("brctl addbr br100 up");
+  system("ifconfig br100 down");
+  system("ip link add link e101-003-0 name e101-003-0.100 type vlan id 100");
+  system("ifconfig e101-003-0 up");
+  system("ip link set dev e101-003-0.100 up");
+  system("brctl addif br100 e101-003-0.100");
+  system("ip addr add 100.1.1.2/24 dev br100");
+  system("ip addr add  100:1::1/64 dev br100");
+  system("ifconfig br100 up");
+  system("brctl stp br100 on");
+  system("ip neigh add 100.1.1.10 lladdr 00:00:00:00:11:22");
+
+  system("brctl addbr br200 up");
+  system("ifconfig br200 down");
+  system("ip link add link e101-003-0 name e101-003-0.200 type vlan id 200");
+  system("ifconfig e101-003-0 up");
+  system("ip link set dev e101-003-0.200 up");
+  system("brctl addif br200 e101-003-0.200");
+  system("ip addr add 200.1.1.2/24 dev br200");
+  system("ip addr add  200:1::1/64 dev br200");
+  system("ifconfig br200 up");
+  system("brctl stp br200 on");
+
+  system("brctl addbr br201 up");
+  system("ifconfig br201 down");
+  system("ip link add link e101-003-0 name e101-003-0.201 type vlan id 201");
+  system("ifconfig e101-003-0 up");
+  system("ip link set dev e101-003-0.201 up");
+  system("brctl addif br201 e101-003-0.201");
+  system("ip addr add 201.1.1.2/24 dev br201");
+  system("ip addr add  201:1::1/64 dev br201");
+  system("ifconfig br201 up");
+  system("brctl stp br201 on");
+
+
+  printf("___________________________________________\n");
+
+  return RUN_ALL_TESTS();
+}

--- a/src/unit_test/ip_redirect_cfg_test.py
+++ b/src/unit_test/ip_redirect_cfg_test.py
@@ -1,0 +1,248 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+# LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+# FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+
+import cps
+from cps_utils import *
+import sys
+import subprocess
+
+config_data = {
+1: {'vrf-name':'default', 'ifname':'br100'},
+2: {'vrf-name':'default', 'ifname':'br110'},
+3: {'vrf-name':'default', 'ifname':'e101-015-0'},
+}
+
+fail_data = {
+1: {'vrf-name':'default1', 'ifname':'br111'},
+2: {'vrf-name':'default1', 'ifname':'e101-021-0'},
+}
+
+def commit(obj, op):
+    l = []
+    obj_tup = (op, obj.get())
+    l.append(obj_tup)
+    t = CPSTransaction(l)
+    ret = t.commit()
+    if ret:
+        print "Commit success"
+    return ret
+
+
+def usage():
+    print"\n ip_redirect_cfg_test.py run-test"
+    print"\n ip_redirect_cfg_test.py create vrf <name> ifname <name> "
+    print"\n ip_redirect_cfg_test.py delete vrf <name> ifname <name> "
+    print"\n ip_redirect_cfg_test.py show [vrf <name>] [ifname <name>]"
+    print"\n"
+
+
+def exec_shell(cmd):
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    (out, err) = proc.communicate()
+    #print out
+    return out
+
+
+def handle_config(op, vrf, ifname):
+    print(" vrf:", vrf)
+    print(" ifname:", ifname)
+    obj = CPSObject('base-route/ip-redirects-config',
+                     data= {"vrf-name" : vrf,
+                       "ifname" : ifname, })
+    ret = commit(obj, op)
+    return ret
+
+
+
+def handle_get(vrf, ifname):
+    get_list = []
+    get_obj = CPSObject("base-route/ip-redirects-config")
+    if vrf is not None:
+        get_obj.add_attr("vrf-name", vrf)
+    if ifname is not None:
+        get_obj.add_attr("ifname", ifname)
+    if cps.get([get_obj.get()], get_list):
+        if not get_list:
+            get_list = None
+        return get_list
+    else:
+        return None
+
+def handle_show(vrf, ifname):
+    ret = 1
+    get_list = handle_get(vrf, ifname)
+    if get_list is not None:
+        for i in get_list:
+            print_obj(i)
+        ret = 0
+    else:
+        print("\n no objects received")
+    return ret
+
+def test_pre_req_cfg():
+    #print("Test pre requisite config")
+    mode = 'OPX'
+    ret = exec_shell('opx-show-version | grep \"OS_NAME.*Enterprise\"')
+    if ret:
+        mode = 'DoD'
+
+    if mode is 'DoD':
+        #configure via CLI the test pre requisites
+        cmd_list =  ['configure terminal',
+                     'interface ethernet 1/1/15',
+                     'no switchport',
+                     'ip address 15.1.1.1/24',
+                     'exit',
+                     'interface vlan 100',
+                     'ip address 100.1.1.1/24',
+                     'exit',
+                     'interface vlan 110',
+                     'ip address 110.1.1.1/24',
+                     'exit',
+                     'interface range ethernet 1/1/9,1/1/19',
+                     'switchport mode trunk',
+                     'switchport trunk allowed vlan 100,110',
+                     'exit']
+        cfg_file = open('/tmp/test_pre_req', 'w')
+        for item in cmd_list:
+            print>>cfg_file, item
+        cfg_file.close()
+        exec_shell('sudo -u admin clish --b /tmp/test_pre_req')
+    else:
+        #configure via linux commands the test pre requisites
+        exec_shell('brctl addbr br100 up')
+        exec_shell('ifconfig br100 down')
+        exec_shell('ip link add link e101-009-0 name e101-009-0.100 type vlan id 100')
+        exec_shell('ip link add link e101-019-0 name e101-019-0.100 type vlan id 100')
+        exec_shell('ifconfig e101-009-0 up')
+        exec_shell('ifconfig e101-019-0 up')
+        exec_shell('ip link set dev e101-009-0.100 up')
+        exec_shell('ip link set dev e101-019-0.100 up')
+        exec_shell('brctl addif br100 e101-009-0.100')
+        exec_shell('brctl addif br100 e101-019-0.100')
+        exec_shell('ip addr add 100.1.1.1/24 dev br100')
+        exec_shell('ifconfig br100 up')
+        exec_shell('brctl stp br100 on')
+
+        exec_shell('brctl addbr br110 up')
+        exec_shell('ifconfig br110 down')
+        exec_shell('ip link add link e101-009-0 name e101-009-0.110 type vlan id 110')
+        exec_shell('ip link add link e101-019-0 name e101-019-0.110 type vlan id 110')
+        exec_shell('ifconfig e101-009-0 up')
+        exec_shell('ifconfig e101-019-0 up')
+        exec_shell('ip link set dev e101-009-0.110 up')
+        exec_shell('ip link set dev e101-019-0.110 up')
+        exec_shell('brctl addif br100 e101-009-0.110')
+        exec_shell('brctl addif br100 e101-019-0.110')
+        exec_shell('ip addr add 110.1.1.1/24 dev br110')
+        exec_shell('ifconfig br110 up')
+        exec_shell('brctl stp br110 on')
+
+        exec_shell('ifconfig e101-015-0 up')
+        exec_shell('ip addr add 15.1.1.1/24 dev e101-015-0')
+
+
+if __name__ == '__main__':
+    vrf = None
+    af = 0
+    show = 0
+    delete = 0
+    create = 0
+    ifname = None
+    ip = None
+    mac = ""
+    ret = 0
+    if len(sys.argv) == 1:
+        usage()
+    else:
+        if (sys.argv[1] in ["show", "create", "delete"]):
+            print("len = ", len(sys.argv))
+            print("command : ", sys.argv[1])
+            arglen = len(sys.argv)
+            if (sys.argv[1] == "show"):
+                show = 1
+            elif (sys.argv[1] == "delete"):
+                delete = 1
+            elif (sys.argv[1] == "create"):
+                create = 1
+            i = 2
+            while (i < arglen):
+                print("\n iteration i", i)
+                if (sys.argv[i] == "vrf"):
+                    i = i + 1
+                    if (i > arglen):
+                        print"\n\n Please reenter vrf-name"
+                    vrf = sys.argv[i]
+                elif (sys.argv[i] == "ifname"):
+                    i = i + 1
+                    if (i > arglen):
+                        print"\n\n please enter ifname"
+                    ifname = sys.argv[i]
+                i = i + 1
+            print(
+                "\n\n cmd with vrf, ifname ",
+                vrf,
+                ifname)
+            if (show):
+                ret = handle_show(
+                    vrf,
+                    ifname)
+            elif (delete):
+                if not handle_config(
+                           "delete",
+                           vrf,
+                           ifname):
+                    ret = 1
+            elif (create):
+                if not handle_config(
+                           "create",
+                           vrf,
+                           ifname):
+                    ret = 1
+        elif (sys.argv[1] in ["run-test"]):
+            test_pre_req_cfg()
+            i = 1
+            while(i<=3):
+                entry = config_data[i]
+                if not handle_config("create", entry['vrf-name'], entry['ifname']):
+                    ret = 1
+                if handle_get(entry['vrf-name'], entry['ifname']) is None:
+                    ret = 1
+                i+=1
+            i = 1
+            while(i<=3):
+                entry = config_data[i]
+                if not handle_config("delete", entry['vrf-name'], entry['ifname']):
+                    ret = 1
+                if handle_get(entry['vrf-name'], entry['ifname']) is not None:
+                    ret = 1
+                i+=1
+            i = 1
+            while(i<=3):
+                entry = config_data[i]
+                if handle_get(entry['vrf-name'], entry['ifname']) is not None:
+                    ret = 1
+                i+=1
+            i = 1
+            while(i<=2):
+                entry = fail_data[i]
+                if handle_config("create", entry['vrf-name'], entry['ifname']):
+                    ret = 1
+                if handle_get(entry['vrf-name'], entry['ifname']) is not None:
+                    ret = 1
+                i+=1
+        else:
+            usage()
+    sys.exit(ret)

--- a/src/unit_test/nas_rt_offload_cps_unittest.cpp
+++ b/src/unit_test/nas_rt_offload_cps_unittest.cpp
@@ -1,0 +1,410 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * nas_rt_offload_cps_unittest.cpp
+ * UT to validate the offload message processing functionality in nas-l3
+ */
+
+
+#include "cps_api_events.h"
+
+#include "std_mac_utils.h"
+#include "std_ip_utils.h"
+
+#include "dell-base-routing.h"
+#include "nas_rt_api.h"
+#include "ds_common_types.h"
+#include "cps_class_map.h"
+#include "cps_api_object.h"
+#include "cps_api_operation.h"
+#include "cps_class_map.h"
+#include "cps_api_object_key.h"
+
+#include "nas_os_l3.h"
+
+#include <sys/time.h>
+#include <time.h>
+#include <math.h>
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+
+static cps_api_return_code_t nas_ut_rt_cfg (bool is_add, const char *ip_addr, uint32_t prefix_len, uint8_t af)
+{
+    cps_api_object_t obj = cps_api_object_create();
+
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+           BASE_ROUTE_OBJ_OBJ,cps_api_qualifier_TARGET);
+
+    /*
+     * Check mandatory route attributes
+     *  BASE_ROUTE_OBJ_ENTRY_AF,     BASE_ROUTE_OBJ_VRF_NAME);
+     * BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,   BASE_ROUTE_OBJ_ENTRY_PREFIX_LEN;
+     */
+
+    cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_VRF_NAME, FIB_DEFAULT_VRF_NAME,
+                            sizeof(FIB_DEFAULT_VRF_NAME));
+    if (af == AF_INET) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_AF,AF_INET);
+
+        uint32_t ip;
+        struct in_addr a;
+        inet_aton(ip_addr, &a);
+        ip=a.s_addr;
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,&ip,sizeof(ip));
+    } else if (af == AF_INET6) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_AF,AF_INET6);
+
+        struct in6_addr a6;
+        inet_pton(AF_INET6, ip_addr, &a6);
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,&a6,sizeof(struct in6_addr));
+    }
+
+    cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_PREFIX_LEN,prefix_len);
+
+    cps_api_attr_id_t ids[3];
+    const int ids_len = sizeof(ids)/sizeof(*ids);
+    ids[0] = BASE_ROUTE_OBJ_ENTRY_NH_LIST;
+
+    uint32_t gw_idx = if_nametoindex("br100");
+    ids[1] = 0;
+    ids[2] = BASE_ROUTE_OBJ_ENTRY_NH_LIST_IFINDEX;
+    cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_U32,
+                         (void *)&gw_idx, sizeof(uint32_t));
+
+    cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_NH_COUNT,1);
+
+    /*
+     * CPS transaction
+     */
+    cps_api_transaction_params_t tr;
+    cps_api_transaction_init(&tr);
+
+    if (is_add)
+        cps_api_create(&tr,obj);
+    else
+        cps_api_delete(&tr,obj);
+
+    cps_api_commit(&tr);
+    cps_api_transaction_close(&tr);
+
+    return cps_api_ret_code_OK;
+}
+
+
+static cps_api_return_code_t nas_ut_neigh_cfg (bool is_add, const char *ip_addr, uint8_t af)
+{
+
+    cps_api_object_t obj = cps_api_object_create();
+
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+              BASE_ROUTE_OBJ_NBR,cps_api_qualifier_TARGET);
+
+    if (af == AF_INET) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_AF,AF_INET);
+
+        uint32_t ip;
+        struct in_addr a;
+        inet_aton(ip_addr, &a);
+        ip=a.s_addr;
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_NBR_ADDRESS,&ip,sizeof(ip));
+    } else if (af == AF_INET6) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_AF,AF_INET6);
+
+        struct in6_addr a6;
+        inet_pton(AF_INET6, ip_addr, &a6);
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_NBR_ADDRESS,&a6,sizeof(struct in6_addr));
+    }
+
+    //cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_TYPE,BASE_ROUTE_RT_TYPE_STATIC);
+    const char *if_name = "br100";
+    cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_NBR_IFNAME, if_name, strlen(if_name)+1);
+
+    hal_mac_addr_t hw_addr = {0x00, 0x02, 0x03, 0x04, 0x05, 0x06};
+
+    char mac_addr[256];
+    memset(mac_addr, '\0', sizeof(mac_addr));
+    std_mac_to_string (&hw_addr, mac_addr, 256);
+    cps_api_object_attr_add(obj, BASE_ROUTE_OBJ_NBR_MAC_ADDR, (const void *)mac_addr,
+                            strlen(mac_addr)+1);
+
+    /*
+     * CPS transaction
+     */
+    cps_api_transaction_params_t tr;
+    cps_api_transaction_init(&tr);
+
+    if (is_add)
+        cps_api_create(&tr,obj);
+    else
+        cps_api_delete(&tr,obj);
+
+    cps_api_commit(&tr);
+
+    cps_api_transaction_close(&tr);
+
+    return cps_api_ret_code_OK;
+}
+
+static void nas_route_dump_arp_object_content(cps_api_object_t obj){
+    void *p_ip_addr = NULL;
+    uint32_t af = 0;
+    char str[INET6_ADDRSTRLEN];
+
+    cps_api_object_it_t it;
+    cps_api_object_it_begin(obj,&it);
+
+    for ( ; cps_api_object_it_valid(&it) ; cps_api_object_it_next(&it) ) {
+
+        switch (cps_api_object_attr_id(it.attr)) {
+
+        case BASE_ROUTE_OBJ_NBR_ADDRESS:
+            p_ip_addr = cps_api_object_attr_data_bin(it.attr);
+
+            if (af == AF_INET || af == AF_INET6) {
+                int addr_len = ((af == AF_INET6)?INET6_ADDRSTRLEN:INET_ADDRSTRLEN);
+                std::cout<<"IP Address "<<inet_ntop(af,p_ip_addr,str, addr_len)<<std::endl;
+            }
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_AF:
+            af = cps_api_object_attr_data_u32(it.attr);
+            if (p_ip_addr) {
+                int addr_len = ((af == AF_INET6)?INET6_ADDRSTRLEN:INET_ADDRSTRLEN);
+                if (af == AF_INET || af == AF_INET6)
+                    std::cout<<"IP Address "<<inet_ntop(af,p_ip_addr,str,addr_len)<<std::endl;
+            }
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_MAC_ADDR:
+            {
+                char mstring[50];
+                memset(mstring,'\0',sizeof(mstring));
+                memcpy(mstring,cps_api_object_attr_data_bin(it.attr),
+                        cps_api_object_attr_len(it.attr));
+                std::cout<<"MAC "<<mstring<<std::endl;
+            }
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_VRF_ID:
+            std::cout<<"VRF Id "<<cps_api_object_attr_data_u32(it.attr)<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_IFINDEX:
+            std::cout<<"Ifindex "<<cps_api_object_attr_data_u32(it.attr)<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_VRF_NAME:
+            char vrf_name[256];
+            memset(vrf_name,'\0',sizeof(vrf_name));
+            memcpy(vrf_name, cps_api_object_attr_data_bin(it.attr), cps_api_object_attr_len(it.attr));
+            std::cout<<"VRF-name "<<vrf_name<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_IFNAME:
+            char if_name[256];
+            memset(if_name,'\0',sizeof(if_name));
+            memcpy(if_name, cps_api_object_attr_data_bin(it.attr), cps_api_object_attr_len(it.attr));
+            std::cout<<"If-name "<<if_name<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_FLAGS:
+            std::cout<<"Flags "<<cps_api_object_attr_data_u32(it.attr)<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_STATE:
+            std::cout<<"State "<<cps_api_object_attr_data_u32(it.attr)<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_TYPE:
+            std::cout<<"Type "<<cps_api_object_attr_data_u32(it.attr)<<std::endl;
+            break;
+
+        default:
+            break;
+        }
+    }
+}
+
+static cps_api_return_code_t nas_ut_validate_neigh_cfg (const char *ip_addr, uint8_t af)
+{
+    cps_api_return_code_t rc = cps_api_ret_code_ERR;
+    cps_api_get_params_t gp;
+    cps_api_get_request_init(&gp);
+
+    cps_api_object_t obj = cps_api_object_list_create_obj_and_append(gp.filters);
+
+
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+              BASE_ROUTE_OBJ_NBR,cps_api_qualifier_TARGET);
+
+    if (af == AF_INET) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_AF,AF_INET);
+
+        uint32_t ip;
+        struct in_addr a;
+        inet_aton(ip_addr, &a);
+        ip=a.s_addr;
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_NBR_ADDRESS,&ip,sizeof(ip));
+    } else if (af == AF_INET6) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_AF,AF_INET6);
+
+        struct in6_addr a6;
+        inet_pton(AF_INET6, ip_addr, &a6);
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_NBR_ADDRESS,&a6,sizeof(struct in6_addr));
+    }
+
+   if (cps_api_get(&gp)==cps_api_ret_code_OK) {
+       size_t mx = cps_api_object_list_size(gp.list);
+        if (mx)
+        {
+            rc = cps_api_ret_code_OK;
+            std::cout<<"ARP ENTRY "<<std::endl;
+            std::cout<<"================================="<<std::endl;
+
+            for ( size_t ix = 0 ; ix < mx ; ++ix ) {
+                obj = cps_api_object_list_get(gp.list,ix);
+                nas_route_dump_arp_object_content(obj);
+                std::cout<<std::endl;
+                std::cout<<"================================="<<std::endl;
+            }
+        }
+
+    }
+
+    cps_api_get_request_close(&gp);
+    return rc;
+}
+
+
+static cps_api_return_code_t nas_rt_offload_ut_v4_cfg_add ()
+{
+    nas_ut_rt_cfg (1, "101.101.101.0", 24, AF_INET);
+    nas_ut_neigh_cfg (1, "101.101.101.10", AF_INET);
+
+    return cps_api_ret_code_OK;
+}
+
+static cps_api_return_code_t nas_rt_offload_ut_v6_cfg_add ()
+{
+    nas_ut_rt_cfg (1, "101:101::0", 64, AF_INET6);
+    nas_ut_neigh_cfg (1, "101:101::10", AF_INET6);
+
+    return cps_api_ret_code_OK;
+}
+
+static cps_api_return_code_t nas_rt_offload_validate_v4_cfg(bool is_add)
+{
+    cps_api_return_code_t rc = nas_ut_validate_neigh_cfg ("101.101.101.10", AF_INET);
+
+    return rc;
+}
+
+static cps_api_return_code_t nas_rt_offload_validate_v6_cfg(bool is_add)
+{
+    cps_api_return_code_t rc = nas_ut_validate_neigh_cfg ("101:101::10", AF_INET6);
+
+    return rc;
+
+}
+
+static cps_api_return_code_t nas_rt_offload_ut_v4_cfg_del ()
+{
+    nas_ut_rt_cfg (0, "101.101.101.0", 24, AF_INET);
+    nas_ut_neigh_cfg (0, "101.101.101.10", AF_INET);
+
+    return cps_api_ret_code_OK;
+}
+
+static cps_api_return_code_t nas_rt_offload_ut_v6_cfg_del ()
+{
+    nas_ut_rt_cfg (0, "101:101::0", 64, AF_INET6);
+    nas_ut_neigh_cfg (0, "101:101::10", AF_INET6);
+
+    return cps_api_ret_code_OK;
+}
+
+
+TEST(std_nas_route_test, nas_rt_offload_ut) {
+    cps_api_return_code_t rc;
+    nas_rt_offload_ut_v4_cfg_add();
+    nas_rt_offload_ut_v6_cfg_add();
+
+    /* wait for few secs after configuration, to make sure NAS-L3 processed those netlink events */
+    sleep (5);
+    rc = nas_rt_offload_validate_v4_cfg(1);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    rc = nas_rt_offload_validate_v6_cfg(1);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    nas_rt_offload_ut_v4_cfg_del();
+    nas_rt_offload_ut_v6_cfg_del();
+
+    /* wait for few secs after config delete, to make sure NAS-L3 processed those netlink events */
+    sleep (5);
+    rc = nas_rt_offload_validate_v4_cfg(0);
+    ASSERT_TRUE(rc != cps_api_ret_code_OK);
+
+    rc = nas_rt_offload_validate_v6_cfg(0);
+    ASSERT_TRUE(rc != cps_api_ret_code_OK);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+
+
+  /* configure the test pre-requisite */
+  printf("___________________________________________\n");
+  system("ip address add 6.6.6.1/24  dev e101-005-0");
+  system("ifconfig e101-005-0");
+  /* Incase of premium package, all the ports are part of default bridge,
+   * remove it from the bridge to operate as the router intf. */
+  system("brctl addbr br100 up");
+  system("ifconfig br100 down");
+  system("ip link add link e101-003-0 name e101-003-0.100 type vlan id 100");
+  system("ifconfig e101-003-0 up");
+  system("ip link set dev e101-003-0.100 up");
+  system("brctl addif br100 e101-003-0.100");
+  system("ip addr add 100.1.1.2/24 dev br100");
+  system("ip neigh add 100.1.1.10 lladdr 00:00:00:00:11:22");
+  system("ifconfig br100 up");
+  system("brctl stp br100 on");
+
+  system("brctl addbr br200 up");
+  system("ip link add link e101-003-0 name e101-003-0.200 type vlan id 200");
+  system("ifconfig e101-003-0 up");
+  system("ip link set dev e101-003-0.200 up");
+  system("brctl addif br200 e101-003-0.200");
+  system("ip addr add 200.1.1.2/24 dev br200");
+  system("ifconfig br200 up");
+  system("brctl stp br200 on");
+
+  printf("___________________________________________\n");
+
+  return RUN_ALL_TESTS();
+}

--- a/src/unit_test/nas_rt_util_unittest.cpp
+++ b/src/unit_test/nas_rt_util_unittest.cpp
@@ -1,0 +1,714 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * nas_rt_util_unittest.cpp
+ * Utility functions used by unit tests
+ */
+
+
+#include "nas_rt_util_unittest.h"
+
+#include "dell-base-routing.h"
+#include "nas_os_l3.h"
+#include "nas_rt_api.h"
+#include "vrf-mgmt.h"
+#include "ietf-network-instance.h"
+
+#include <iostream>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <net/if.h>
+
+cps_api_return_code_t nas_ut_vrf_cfg (const char *vrf_name, bool is_add)
+{
+    cps_api_return_code_t rc = cps_api_ret_code_OK;
+    cps_api_object_t obj = cps_api_object_create();
+
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+                                    NI_NETWORK_INSTANCES_OBJ,cps_api_qualifier_TARGET);
+
+    cps_api_object_attr_add(obj,NI_NETWORK_INSTANCES_NETWORK_INSTANCE_NAME, vrf_name,
+                            strlen(vrf_name)+1);
+    /*
+     * CPS transaction
+     */
+    cps_api_transaction_params_t tr;
+    cps_api_transaction_init(&tr);
+
+    if (is_add)
+        cps_api_create(&tr,obj);
+    else
+        cps_api_delete(&tr,obj);
+
+    rc = cps_api_commit(&tr);
+    cps_api_transaction_close(&tr);
+
+    return rc;
+}
+
+cps_api_return_code_t nas_ut_intf_vrf_cfg (const char *vrf_name, const char *if_name, bool is_add)
+{
+    cps_api_return_code_t rc = cps_api_ret_code_OK;
+    cps_api_object_t obj = cps_api_object_create();
+
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+                                    VRF_MGMT_INTF_BIND_NI_OBJ,cps_api_qualifier_TARGET);
+
+    cps_api_object_attr_add(obj,VRF_MGMT_INTF_BIND_NI_INPUT_NI_NAME, vrf_name,
+                            strlen(vrf_name)+1);
+    cps_api_object_attr_add(obj,VRF_MGMT_INTF_BIND_NI_INPUT_INTERFACE, if_name,
+                            strlen(if_name)+1);
+    cps_api_object_attr_add_u32(obj,VRF_MGMT_INTF_BIND_NI_INPUT_OPERATION,
+                                (is_add ? BASE_CMN_OPERATION_TYPE_CREATE : BASE_CMN_OPERATION_TYPE_DELETE));
+    /*
+     * CPS transaction
+     */
+    cps_api_transaction_params_t tr;
+    cps_api_transaction_init(&tr);
+
+    rc = cps_api_action(&tr,obj);
+
+    cps_api_commit(&tr);
+
+    if (is_add && (rc == cps_api_ret_code_OK)) {
+        cps_api_object_attr_t if_index  = cps_api_object_attr_get(obj, VRF_MGMT_INTF_BIND_NI_OUTPUT_IFINDEX);
+        const char *rt_if_name = (const char *)cps_api_object_get_data(obj,
+                                                                    VRF_MGMT_INTF_BIND_NI_OUTPUT_IFNAME);
+        const char *mac_addr = (const char *)cps_api_object_get_data(obj,
+                                                                     VRF_MGMT_INTF_BIND_NI_OUTPUT_MAC_ADDR);
+        if ((if_index == nullptr) || (rt_if_name == nullptr) || (mac_addr == nullptr)) {
+            return cps_api_ret_code_ERR;
+        }
+        std::cout<<"VRF:"<<vrf_name<<" If-name:"<<if_name<<std::endl;
+        std::cout<<"Router If-name:"<<rt_if_name<<" If-index:"<<cps_api_object_attr_data_u32(if_index)<<" mac-addr:"<<mac_addr<<std::endl;
+    }
+    cps_api_transaction_close(&tr);
+
+    return rc;
+}
+
+cps_api_return_code_t nas_ut_intf_mgmt_vrf_cfg (const char *vrf_name, const char *if_name, bool is_add)
+{
+    cps_api_return_code_t rc = cps_api_ret_code_OK;
+    cps_api_object_t obj = cps_api_object_create();
+
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+                                    NI_IF_INTERFACES_INTERFACE_OBJ,cps_api_qualifier_TARGET);
+
+    cps_api_object_attr_add(obj,NI_IF_INTERFACES_INTERFACE_BIND_NI_NAME, vrf_name,
+                            strlen(vrf_name)+1);
+    cps_api_object_attr_add(obj,IF_INTERFACES_INTERFACE_NAME, if_name,
+                            strlen(if_name)+1);
+    /*
+     * CPS transaction
+     */
+    cps_api_transaction_params_t tr;
+    cps_api_transaction_init(&tr);
+
+    if (is_add)
+        cps_api_create(&tr,obj);
+    else
+        cps_api_delete(&tr,obj);
+
+    rc = cps_api_commit(&tr);
+    cps_api_transaction_close(&tr);
+
+    return rc;
+}
+
+
+cps_api_return_code_t nas_ut_rt_cfg (const char *rt_vrf_name, bool is_add, const char *ip_addr, uint32_t prefix_len,
+                                     uint8_t af, const char *nh_vrf_name, const char *nh_addr, const char *if_name)
+{
+    cps_api_object_t obj = cps_api_object_create();
+
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+           BASE_ROUTE_OBJ_OBJ,cps_api_qualifier_TARGET);
+
+    /*
+     * Check mandatory route attributes
+     */
+
+    if (rt_vrf_name) {
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_VRF_NAME, rt_vrf_name,
+                                strlen(rt_vrf_name)+1);
+    }
+    if (nh_vrf_name) {
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_ENTRY_NH_VRF_NAME, nh_vrf_name,
+                                strlen(nh_vrf_name)+1);
+    }
+
+    if (af == AF_INET) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_AF,AF_INET);
+
+        uint32_t ip;
+        struct in_addr a;
+        inet_aton(ip_addr, &a);
+        ip=a.s_addr;
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,&ip,sizeof(ip));
+    } else if (af == AF_INET6) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_AF,AF_INET6);
+
+        struct in6_addr a6;
+        inet_pton(AF_INET6, ip_addr, &a6);
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,&a6,sizeof(struct in6_addr));
+    }
+
+    cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_PREFIX_LEN,prefix_len);
+
+    cps_api_attr_id_t ids[3];
+    const int ids_len = sizeof(ids)/sizeof(*ids);
+    ids[0] = BASE_ROUTE_OBJ_ENTRY_NH_LIST;
+
+    if (if_name) {
+        ids[1] = 0;
+        ids[2] = BASE_ROUTE_OBJ_ENTRY_NH_LIST_IFNAME;
+        cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_BIN,
+                             if_name, strlen(if_name)+1);
+    }
+    if (nh_addr) {
+        ids[1] = 0;
+        ids[2] = BASE_ROUTE_OBJ_ENTRY_NH_LIST_NH_ADDR;
+
+        if (af == AF_INET) {
+            uint32_t ip;
+            struct in_addr a;
+            inet_aton(nh_addr, &a);
+            ip=a.s_addr;
+
+            cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_BIN,
+                                 &ip, sizeof(ip));
+        } else if (af == AF_INET6) {
+
+            struct in6_addr a6;
+            inet_pton(AF_INET6, nh_addr, &a6);
+
+            cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_BIN,
+                                 &a6, sizeof(struct in6_addr));
+        }
+    }
+    cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_NH_COUNT,1);
+    /*
+     * CPS transaction
+     */
+    cps_api_transaction_params_t tr;
+    cps_api_transaction_init(&tr);
+
+    if (is_add)
+        cps_api_create(&tr,obj);
+    else
+        cps_api_delete(&tr,obj);
+
+    cps_api_commit(&tr);
+    cps_api_transaction_close(&tr);
+
+    return cps_api_ret_code_OK;
+}
+
+cps_api_return_code_t nas_ut_rt_ipv6_nh_cfg (bool is_add, const char *ip_addr, uint32_t prefix_len, uint8_t af,
+                                             const char *nh_addr1, const char *if_name1,
+                                             const char *nh_addr2, const char *if_name2)
+{
+    if (af != AF_INET6)
+    {
+        return cps_api_ret_code_ERR;
+    }
+    cps_api_object_t obj = cps_api_object_create();
+
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+           BASE_ROUTE_ROUTE_NH_OPERATION_OBJ,cps_api_qualifier_TARGET);
+
+    /*
+     * Check mandatory route attributes
+     */
+
+    cps_api_object_attr_add_u32(obj,BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_AF,AF_INET6);
+
+    struct in6_addr a6;
+    inet_pton(AF_INET6, ip_addr, &a6);
+
+    cps_api_object_attr_add(obj,BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_ROUTE_PREFIX,&a6,sizeof(struct in6_addr));
+
+    cps_api_object_attr_add_u32(obj,BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_PREFIX_LEN,prefix_len);
+
+    cps_api_attr_id_t ids[3];
+    int nh_count = 0;
+    const int ids_len = sizeof(ids)/sizeof(*ids);
+    ids[0] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST;
+
+    if (if_name1) {
+        uint32_t gw_idx = if_nametoindex(if_name1);
+        ids[1] = 0;
+        ids[2] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST_IFINDEX;
+        cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_U32,
+                             (void *)&gw_idx, sizeof(uint32_t));
+        nh_count = 1;
+    }
+    if (nh_addr1) {
+        ids[1] = 0;
+        ids[2] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST_NH_ADDR;
+
+        struct in6_addr a6;
+        inet_pton(AF_INET6, nh_addr1, &a6);
+
+        cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_BIN,
+                             &a6, sizeof(struct in6_addr));
+        nh_count = 1;
+    }
+
+    if (if_name2) {
+        uint32_t gw_idx = if_nametoindex(if_name2);
+        ids[1] = 1;
+        ids[2] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST_IFINDEX;
+        cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_U32,
+                             (void *)&gw_idx, sizeof(uint32_t));
+        nh_count = 2;
+    }
+    if (nh_addr2) {
+        ids[1] = 1;
+        ids[2] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST_NH_ADDR;
+
+        struct in6_addr a6;
+        inet_pton(AF_INET6, nh_addr2, &a6);
+
+        cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_BIN,
+                             &a6, sizeof(struct in6_addr));
+        nh_count = 2;
+    }
+
+    cps_api_object_attr_add_u32(obj,BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_COUNT,nh_count);
+    if (is_add)
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_OPERATION,BASE_ROUTE_RT_OPERATION_TYPE_APPEND);
+    else
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_OPERATION,BASE_ROUTE_RT_OPERATION_TYPE_DELETE);
+    /*
+     * CPS transaction
+     */
+    cps_api_transaction_params_t tr;
+    cps_api_transaction_init(&tr);
+
+    cps_api_action(&tr,obj);
+
+    cps_api_commit(&tr);
+    cps_api_transaction_close(&tr);
+
+    return cps_api_ret_code_OK;
+}
+
+
+cps_api_return_code_t nas_ut_neigh_cfg (bool is_add, const char *ip_addr, uint8_t af, const char *if_name, hal_mac_addr_t *hw_addr)
+{
+
+    cps_api_object_t obj = cps_api_object_create();
+
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+              BASE_ROUTE_OBJ_NBR,cps_api_qualifier_TARGET);
+
+    if (af == AF_INET) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_AF,AF_INET);
+
+        uint32_t ip;
+        struct in_addr a;
+        inet_aton(ip_addr, &a);
+        ip=a.s_addr;
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_NBR_ADDRESS,&ip,sizeof(ip));
+    } else if (af == AF_INET6) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_AF,AF_INET6);
+
+        struct in6_addr a6;
+        inet_pton(AF_INET6, ip_addr, &a6);
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_NBR_ADDRESS,&a6,sizeof(struct in6_addr));
+    }
+
+    //cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_TYPE,BASE_ROUTE_RT_TYPE_STATIC);
+    cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_NBR_IFNAME, if_name, strlen(if_name)+1);
+
+    char mac_addr[256];
+    memset(mac_addr, '\0', sizeof(mac_addr));
+    std_mac_to_string (hw_addr, mac_addr, 256);
+    cps_api_object_attr_add(obj, BASE_ROUTE_OBJ_NBR_MAC_ADDR, (const void *)mac_addr,
+                            strlen(mac_addr)+1);
+
+    /*
+     * CPS transaction
+     */
+    cps_api_transaction_params_t tr;
+    cps_api_transaction_init(&tr);
+
+    if (is_add)
+        cps_api_create(&tr,obj);
+    else
+        cps_api_delete(&tr,obj);
+
+    cps_api_commit(&tr);
+
+    cps_api_transaction_close(&tr);
+
+    return cps_api_ret_code_OK;
+}
+
+void nas_route_dump_arp_object_content(cps_api_object_t obj){
+    void *p_ip_addr = NULL;
+    uint32_t af = 0;
+    char str[INET6_ADDRSTRLEN];
+
+    cps_api_object_it_t it;
+    cps_api_object_it_begin(obj,&it);
+
+    for ( ; cps_api_object_it_valid(&it) ; cps_api_object_it_next(&it) ) {
+
+        switch (cps_api_object_attr_id(it.attr)) {
+
+        case BASE_ROUTE_OBJ_NBR_ADDRESS:
+            p_ip_addr = cps_api_object_attr_data_bin(it.attr);
+
+            if (af == AF_INET || af == AF_INET6) {
+                int addr_len = ((af == AF_INET6)?INET6_ADDRSTRLEN:INET_ADDRSTRLEN);
+                std::cout<<"IP Address "<<inet_ntop(af,p_ip_addr,str, addr_len)<<std::endl;
+            }
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_AF:
+            af = cps_api_object_attr_data_u32(it.attr);
+            if (p_ip_addr) {
+                int addr_len = ((af == AF_INET6)?INET6_ADDRSTRLEN:INET_ADDRSTRLEN);
+                if (af == AF_INET || af == AF_INET6)
+                    std::cout<<"IP Address "<<inet_ntop(af,p_ip_addr,str,addr_len)<<std::endl;
+            }
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_MAC_ADDR:
+            {
+                char mstring[50];
+                memset(mstring,'\0',sizeof(mstring));
+                memcpy(mstring,cps_api_object_attr_data_bin(it.attr),
+                        cps_api_object_attr_len(it.attr));
+                std::cout<<"MAC "<<mstring<<std::endl;
+            }
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_VRF_ID:
+            std::cout<<"VRF Id "<<cps_api_object_attr_data_u32(it.attr)<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_IFINDEX:
+            std::cout<<"Ifindex "<<cps_api_object_attr_data_u32(it.attr)<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_VRF_NAME:
+            char vrf_name[256];
+            memset(vrf_name,'\0',sizeof(vrf_name));
+            memcpy(vrf_name, cps_api_object_attr_data_bin(it.attr), cps_api_object_attr_len(it.attr));
+            std::cout<<"VRF-name: "<<vrf_name<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_IFNAME:
+            char if_name[256];
+            memset(if_name,'\0',sizeof(if_name));
+            memcpy(if_name, cps_api_object_attr_data_bin(it.attr), cps_api_object_attr_len(it.attr));
+            std::cout<<"If-name "<<if_name<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_FLAGS:
+            std::cout<<"Flags "<<cps_api_object_attr_data_u32(it.attr)<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_STATE:
+            std::cout<<"State "<<cps_api_object_attr_data_u32(it.attr)<<std::endl;
+            break;
+
+        case BASE_ROUTE_OBJ_NBR_TYPE:
+            std::cout<<"Type "<<cps_api_object_attr_data_u32(it.attr)<<std::endl;
+            break;
+
+        default:
+            break;
+        }
+    }
+}
+
+void nas_route_dump_route_object_content(cps_api_object_t obj) {
+
+    char str[INET6_ADDRSTRLEN];
+    char if_name[IFNAMSIZ];
+    uint32_t addr_len = 0, af_data = 0;
+    uint32_t nhc = 0, nh_itr = 0;
+
+    cps_api_object_it_t it;
+    cps_api_object_it_begin(obj,&it);
+
+    cps_api_object_attr_t af       = cps_api_object_attr_get(obj, BASE_ROUTE_OBJ_ENTRY_AF);
+    af_data = cps_api_object_attr_data_u32(af) ;
+
+    addr_len = ((af_data == AF_INET) ? INET_ADDRSTRLEN: INET6_ADDRSTRLEN);
+
+    const char *rt_vrf_name = (const char *)cps_api_object_get_data(obj,
+                                                                    BASE_ROUTE_OBJ_VRF_NAME);
+    const char *nh_vrf_name = (const char *)cps_api_object_get_data(obj,
+                                                                    BASE_ROUTE_OBJ_ENTRY_NH_VRF_NAME);
+    cps_api_object_attr_t prefix   = cps_api_object_attr_get(obj, BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX);
+    cps_api_object_attr_t pref_len = cps_api_object_attr_get(obj, BASE_ROUTE_OBJ_ENTRY_PREFIX_LEN);
+    cps_api_object_attr_t nh_count = cps_api_object_attr_get(obj, BASE_ROUTE_OBJ_ENTRY_NH_COUNT);
+    std::cout<<"Route VRF:"<<rt_vrf_name<<" NH VRF:"<<nh_vrf_name<<" AF "<<((af_data == AF_INET) ? "IPv4" : "IPv6")<<","<<
+        inet_ntop(af_data, cps_api_object_attr_data_bin(prefix), str,addr_len)<<"/"<<
+        cps_api_object_attr_data_u32(pref_len)<<std::endl;
+    if (nh_count != CPS_API_ATTR_NULL) {
+        nhc = cps_api_object_attr_data_u32(nh_count);
+        std::cout<<"NHC "<<nhc<<std::endl;
+    }
+
+    for (nh_itr = 0; nh_itr < nhc; nh_itr++)
+    {
+        cps_api_attr_id_t ids[3] = { BASE_ROUTE_OBJ_ENTRY_NH_LIST,
+            0, BASE_ROUTE_OBJ_ENTRY_NH_LIST_NH_ADDR};
+        const int ids_len = sizeof(ids)/sizeof(*ids);
+        ids[1] = nh_itr;
+
+        cps_api_object_attr_t attr = cps_api_object_e_get(obj,ids,ids_len);
+        if (attr != CPS_API_ATTR_NULL)
+            std::cout<<"NextHop "<<inet_ntop(af_data,cps_api_object_attr_data_bin(attr),str,addr_len)<<std::endl;
+
+        ids[2] = BASE_ROUTE_OBJ_ENTRY_NH_LIST_IFINDEX;
+        attr = cps_api_object_e_get(obj,ids,ids_len);
+        if (attr != CPS_API_ATTR_NULL)
+            if_indextoname((int)cps_api_object_attr_data_u32(attr), if_name);
+        std::cout<<"IfIndex "<<if_name<<"("<<cps_api_object_attr_data_u32(attr)<<")"<<std::endl;
+
+        ids[2] = BASE_ROUTE_OBJ_ENTRY_NH_LIST_WEIGHT;
+        attr = cps_api_object_e_get(obj,ids,ids_len);
+        if (attr != CPS_API_ATTR_NULL)
+            std::cout<<"Weight "<<cps_api_object_attr_data_u32(attr)<<std::endl;
+
+        ids[2] = BASE_ROUTE_OBJ_ENTRY_NH_LIST_RESOLVED;
+        attr = cps_api_object_e_get(obj,ids,ids_len);
+        if (attr != CPS_API_ATTR_NULL)
+            std::cout<<"Is Next Hop Resolved "<<cps_api_object_attr_data_u32(attr)<<std::endl;
+    }
+}
+
+
+cps_api_return_code_t nas_ut_validate_neigh_cfg (const char *vrf_name, uint32_t af, const char *ip_addr,
+                                                 uint32_t state, bool should_exist_in_npu)
+{
+    cps_api_return_code_t rc = cps_api_ret_code_ERR;
+    cps_api_get_params_t gp;
+    cps_api_get_request_init(&gp);
+
+    cps_api_object_t obj = cps_api_object_list_create_obj_and_append(gp.filters);
+
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+              BASE_ROUTE_OBJ_NBR,cps_api_qualifier_TARGET);
+
+    cps_api_set_key_data(obj,BASE_ROUTE_OBJ_VRF_NAME, cps_api_object_ATTR_T_BIN, vrf_name,
+                            strlen(vrf_name)+1);
+    if (af == AF_INET) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_AF,AF_INET);
+
+        uint32_t ip;
+        struct in_addr a;
+        inet_aton(ip_addr, &a);
+        ip=a.s_addr;
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_NBR_ADDRESS,&ip,sizeof(ip));
+    } else if (af == AF_INET6) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_AF,AF_INET6);
+
+        struct in6_addr a6;
+        inet_pton(AF_INET6, ip_addr, &a6);
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_NBR_ADDRESS,&a6,sizeof(struct in6_addr));
+    }
+
+   if (cps_api_get(&gp)==cps_api_ret_code_OK) {
+       size_t mx = cps_api_object_list_size(gp.list);
+        if (mx)
+        {
+            rc = cps_api_ret_code_OK;
+            std::cout<<"ARP ENTRY "<<std::endl;
+            std::cout<<"================================="<<std::endl;
+
+            for ( size_t ix = 0 ; ix < mx ; ++ix ) {
+                obj = cps_api_object_list_get(gp.list,ix);
+
+                nas_route_dump_arp_object_content(obj);
+                std::cout<<std::endl;
+                std::cout<<"================================="<<std::endl;
+                cps_api_object_attr_t prg_done_attr = cps_api_object_attr_get(obj, BASE_ROUTE_OBJ_NBR_NPU_PRG_DONE);
+                cps_api_object_attr_t state_attr = cps_api_object_attr_get(obj, BASE_ROUTE_OBJ_NBR_STATE);
+                if ((prg_done_attr == nullptr) || (state_attr == nullptr)) {
+                    rc = cps_api_ret_code_ERR;
+                    break;
+                }
+                if (should_exist_in_npu && (cps_api_object_attr_data_u32(prg_done_attr) == false)) {
+                    rc = cps_api_ret_code_ERR;
+                    break;
+                }
+                if (cps_api_object_attr_data_u32(state_attr) != state) {
+                    rc = cps_api_ret_code_ERR;
+                    break;
+                }
+            }
+        }
+
+    }
+
+    cps_api_get_request_close(&gp);
+    return rc;
+}
+
+cps_api_return_code_t nas_ut_validate_rt_cfg (const char *rt_vrf_name, uint32_t af, const char *ip_addr, uint32_t prefix_len,
+                                              const char *nh_vrf_name, const char *nh_addr, const char *if_name, bool should_exist_in_npu)
+{
+    cps_api_return_code_t rc = cps_api_ret_code_ERR;
+    cps_api_get_params_t gp;
+    cps_api_get_request_init(&gp);
+
+    cps_api_object_t obj = cps_api_object_list_create_obj_and_append(gp.filters);
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),BASE_ROUTE_OBJ_ENTRY,
+                                    cps_api_qualifier_TARGET);
+
+    cps_api_set_key_data(obj,BASE_ROUTE_OBJ_VRF_NAME, cps_api_object_ATTR_T_BIN, rt_vrf_name,
+                         strlen(rt_vrf_name)+1);
+    cps_api_set_key_data(obj,BASE_ROUTE_OBJ_ENTRY_AF,cps_api_object_ATTR_T_U32,
+                         &af,sizeof(af));
+
+    if (af == AF_INET) {
+        uint32_t ip;
+        struct in_addr a;
+        inet_aton(ip_addr, &a);
+        ip=a.s_addr;
+
+        cps_api_set_key_data(obj,BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,cps_api_object_ATTR_T_BIN, &ip,sizeof(ip));
+    } else if (af == AF_INET6) {
+        struct in6_addr a6;
+        inet_pton(AF_INET6, ip_addr, &a6);
+
+        cps_api_set_key_data (obj,BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,cps_api_object_ATTR_T_BIN, &a6,sizeof(struct in6_addr));
+    }
+    cps_api_set_key_data (obj,BASE_ROUTE_OBJ_ENTRY_PREFIX_LEN, cps_api_object_ATTR_T_U32, &prefix_len, sizeof (prefix_len));
+
+    if (cps_api_get(&gp)==cps_api_ret_code_OK) {
+        size_t mx = cps_api_object_list_size(gp.list);
+        if (mx)
+        {
+            rc = cps_api_ret_code_OK;
+
+            std::cout<<"IP FIB Entries, Family:"<<af<<std::endl;
+            std::cout<<"================================="<<std::endl;
+            for ( size_t ix = 0 ; ix < mx ; ++ix ) {
+                obj = cps_api_object_list_get(gp.list,ix);
+                cps_api_object_attr_t prg_done = cps_api_object_attr_get(obj,
+                                                                         BASE_ROUTE_OBJ_ENTRY_NPU_PRG_DONE);
+                if (prg_done && (cps_api_object_attr_data_u32(prg_done))) {
+                    std::cout<<"IP route exists in NPU:"<<std::endl;
+                    if (should_exist_in_npu == false) {
+                        rc = cps_api_ret_code_ERR;
+                    }
+                } else {
+                    if (should_exist_in_npu) {
+                        rc = cps_api_ret_code_ERR;
+                    }
+                    std::cout<<"IP route not exist in NPU:"<<std::endl;
+                }
+                nas_route_dump_route_object_content(obj);
+                std::cout<<std::endl;
+            }
+        }
+    }
+
+    cps_api_get_request_close(&gp);
+    return rc;
+}
+
+cps_api_return_code_t nas_ut_route_op_spl_nh (bool is_add, const char *vrf_name, const char *ip_addr, uint32_t prefix_len,
+                             uint32_t spl_nh_option, uint8_t af)
+{
+    cps_api_return_code_t rc = cps_api_ret_code_ERR;
+    cps_api_object_t obj = cps_api_object_create();
+
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+           BASE_ROUTE_OBJ_OBJ,cps_api_qualifier_TARGET);
+
+    /*
+     * Check mandatory route attributes
+     *  BASE_ROUTE_OBJ_ENTRY_AF,     BASE_ROUTE_OBJ_VRF_NAME);
+     * BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,   BASE_ROUTE_OBJ_ENTRY_PREFIX_LEN;
+     */
+
+    cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_VRF_NAME, vrf_name,
+                            strlen(vrf_name)+1);
+    if (af == AF_INET) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_AF,AF_INET);
+
+        uint32_t ip;
+        struct in_addr a;
+        inet_aton(ip_addr, &a);
+        ip=a.s_addr;
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,&ip,sizeof(ip));
+    } else if (af == AF_INET6) {
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_AF,AF_INET6);
+
+        struct in6_addr a6;
+        inet_pton(AF_INET6, ip_addr, &a6);
+
+        cps_api_object_attr_add(obj,BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,&a6,sizeof(struct in6_addr));
+    }
+
+    cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_PREFIX_LEN,prefix_len);
+
+    cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_SPECIAL_NEXT_HOP,spl_nh_option);
+
+
+    if (spl_nh_option == BASE_ROUTE_SPECIAL_NEXT_HOP_RECEIVE) {
+        cps_api_attr_id_t ids[3];
+        const int ids_len = sizeof(ids)/sizeof(*ids);
+        ids[0] = BASE_ROUTE_OBJ_ENTRY_NH_LIST;
+
+        uint32_t gw_idx = if_nametoindex("br100");
+        ids[1] = 0;
+        ids[2] = BASE_ROUTE_OBJ_ENTRY_NH_LIST_IFINDEX;
+        cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_U32,
+                             (void *)&gw_idx, sizeof(uint32_t));
+
+        cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_ENTRY_NH_COUNT,1);
+    }
+
+    /*
+     * CPS transaction
+     */
+    cps_api_transaction_params_t tr;
+    rc = cps_api_transaction_init(&tr);
+    if (rc != cps_api_ret_code_OK) {
+        return cps_api_ret_code_ERR;
+    }
+    if (is_add)
+        cps_api_create(&tr,obj);
+    else
+        cps_api_delete(&tr,obj);
+
+    rc = cps_api_commit(&tr);
+    cps_api_transaction_close(&tr);
+    return rc;
+}
+
+

--- a/src/unit_test/nas_rt_util_unittest.h
+++ b/src/unit_test/nas_rt_util_unittest.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * nas_rt_util_unittest.h
+ * Utility functions used by unit tests
+ */
+
+#ifndef __NAS_RT_UTIL_UNITTEST_H__
+#define __NAS_RT_UTIL_UNITTEST_H__
+
+#include "std_mac_utils.h"
+#include "std_ip_utils.h"
+#include "cps_api_events.h"
+#include "ds_common_types.h"
+#include "cps_class_map.h"
+#include "cps_api_object.h"
+#include "cps_class_map.h"
+#include "cps_api_object_key.h"
+
+cps_api_return_code_t nas_ut_rt_cfg (const char *rt_vrf_name, bool is_add, const char *ip_addr, uint32_t prefix_len,
+                                     uint8_t af, const char *nh_vrf_name, const char *nh_addr, const char *if_name);
+cps_api_return_code_t nas_ut_neigh_cfg (bool is_add, const char *ip_addr, uint8_t af, const char *if_name, hal_mac_addr_t *hw_addr);
+void nas_route_dump_arp_object_content(cps_api_object_t obj);
+cps_api_return_code_t nas_ut_validate_neigh_cfg (const char *vrf_name, uint32_t af, const char *ip_addr,
+                                                 uint32_t state, bool should_exist_in_npu);
+cps_api_return_code_t nas_ut_validate_rt_cfg (const char *rt_vrf_name, uint32_t af, const char *ip_addr, uint32_t prefix_len,
+                                              const char *nh_vrf_name, const char *nh_addr, const char *if_name, bool should_exist_in_npu);
+void nas_route_dump_route_object_content(cps_api_object_t obj);
+cps_api_return_code_t nas_ut_rt_ipv6_nh_cfg (bool is_add, const char *ip_addr, uint32_t prefix_len, uint8_t af,
+                                             const char *nh_addr1, const char *if_name1, const char *nh_addr2, const char *if_name2);
+cps_api_return_code_t nas_ut_vrf_cfg (const char *vrf_name, bool is_add);
+cps_api_return_code_t nas_ut_intf_vrf_cfg (const char *vrf_name, const char *if_name, bool is_add);
+cps_api_return_code_t nas_ut_intf_mgmt_vrf_cfg(const char *vrf_name, const char *if_name, bool is_add);
+cps_api_return_code_t nas_ut_route_op_spl_nh (bool is_add, const char *vrf_name, const char *ip_addr, uint32_t prefix_len,
+                                              uint32_t spl_nh_option, uint8_t af);
+#endif /* __NAS_RT_UTIL_UNITTEST_H__ */

--- a/src/unit_test/nas_rt_vrf_unittest.cpp
+++ b/src/unit_test/nas_rt_vrf_unittest.cpp
@@ -1,0 +1,1150 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*
+ * nas_rt_vrf_unittest.cpp
+ */
+#include "nas_rt_util_unittest.h"
+#include "dell-base-routing.h"
+
+#include <gtest/gtest.h>
+#include <iostream>
+#include "sys/time.h"
+#include "math.h"
+
+/* NOTE: Change the back to back connected ports here based on availability in the node, also,
+ * if we are running this test in Enterprise package, make sure "no switchport" command is executed in CLI
+ * on these two ports before running the script. */
+const char *b2b_intf1 = "e101-019-0";
+const char *b2b_intf2 = "e101-020-0";
+const char *DoD_b2b_intf1 = "1/1/19";
+const char *DoD_b2b_intf2 = "1/1/20";
+
+void print_time(char *buffer, int *p_sec, int *p_milli_sec)
+{
+    char buf[50];
+    int millisec;
+    struct tm* tm_info;
+    struct timeval tv;
+
+    gettimeofday(&tv, NULL);
+
+    /* Get the milli-sec */
+    millisec = lrint(tv.tv_usec/1000.0);
+    if (millisec >= 1000) {
+        /* Get the sec from milli-sec and update the milli-sec */
+        tv.tv_sec += millisec/1000;
+        millisec = millisec % 1000;
+    }
+    *p_sec = tv.tv_sec;
+    *p_milli_sec = millisec;
+
+    tm_info = localtime(&tv.tv_sec);
+
+    strftime(buf, 40, "%Y:%m:%d %H:%M:%S", tm_info);
+    snprintf(buffer, 50, "%s.%03d ", buf, millisec);
+
+    return;
+}
+
+
+static void nas_vrf_change_mode(bool is_l3) {
+    int ret = system("opx-show-version | grep \"OS_NAME.*Enterprise\"");
+    if (ret == 0) {
+        FILE *fp;
+
+        fp = fopen("/tmp/test_pre_req","w");
+        fprintf(fp, "configure terminal\n");
+        fprintf(fp, "interface ethernet %s\n", DoD_b2b_intf1);
+        if (is_l3) {
+            fprintf(fp, "no switchport\n");
+        } else {
+            fprintf(fp, "switchport mode access\n");
+        }
+
+        fprintf(fp, "exit\n");
+        fprintf(fp, "interface ethernet %s\n", DoD_b2b_intf2);
+        if (is_l3) {
+            fprintf(fp, "no switchport\n");
+        } else {
+            fprintf(fp, "switchport mode access\n");
+        }
+        fprintf(fp, "exit\n");
+        fflush(fp);
+        system("sudo -u admin clish --b /tmp/test_pre_req");
+    }
+}
+
+
+static void nas_rt_special_next_hop_config(bool is_add, const char *vrf_name) {
+    cps_api_return_code_t rc;
+    rc = nas_ut_route_op_spl_nh (is_add, vrf_name, "44.1.0.0", 16, BASE_ROUTE_SPECIAL_NEXT_HOP_BLACKHOLE, AF_INET);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_route_op_spl_nh (is_add, vrf_name, "44.2.0.0", 16, BASE_ROUTE_SPECIAL_NEXT_HOP_UNREACHABLE, AF_INET);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_route_op_spl_nh (is_add, vrf_name, "44.3.0.0", 16, BASE_ROUTE_SPECIAL_NEXT_HOP_PROHIBIT, AF_INET);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_route_op_spl_nh (is_add, vrf_name, "0.0.0.0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_BLACKHOLE, AF_INET);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    rc = nas_ut_route_op_spl_nh (is_add, vrf_name, "1111:1111::", 64, BASE_ROUTE_SPECIAL_NEXT_HOP_BLACKHOLE, AF_INET6);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_route_op_spl_nh (is_add, vrf_name, "1111:2222::", 64, BASE_ROUTE_SPECIAL_NEXT_HOP_UNREACHABLE, AF_INET6);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_route_op_spl_nh (is_add, vrf_name, "1111:3333::", 64, BASE_ROUTE_SPECIAL_NEXT_HOP_PROHIBIT, AF_INET6);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_route_op_spl_nh (is_add, vrf_name, "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_BLACKHOLE, AF_INET6);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+}
+
+static void nas_rt_special_next_hop_validate(const char *vrf_name, cps_api_return_code_t rc_check) {
+    cps_api_return_code_t rc;
+    sleep(5);
+    rc = nas_ut_validate_rt_cfg (vrf_name, AF_INET, "44.1.0.0", 16, vrf_name, NULL, NULL, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg (vrf_name, AF_INET, "44.2.0.0", 16, vrf_name, NULL, NULL, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg (vrf_name, AF_INET, "44.3.0.0", 16, vrf_name, NULL, NULL, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg (vrf_name, AF_INET, "0.0.0.0", 0, vrf_name, NULL, NULL, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg (vrf_name, AF_INET6,"1111:1111::", 64, vrf_name, NULL, NULL, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc =  nas_ut_validate_rt_cfg (vrf_name, AF_INET6,"1111:2222::", 64, vrf_name, NULL, NULL, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc =  nas_ut_validate_rt_cfg (vrf_name, AF_INET6,"1111:3333::", 64, vrf_name, NULL, NULL, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc =  nas_ut_validate_rt_cfg (vrf_name, AF_INET6,"0::0", 0, vrf_name, NULL, NULL, true);
+    ASSERT_TRUE(rc == rc_check);
+}
+
+static void nas_rt_scal_test(int start_vrf_id, int no_of_vrfs, bool is_add, cps_api_return_code_t rc_check) {
+    char cmd [512];
+    char vrf[10];
+    char vlan[10];
+    int id;
+    cps_api_return_code_t rc;
+
+    for (id = start_vrf_id ;id < (start_vrf_id+no_of_vrfs); id++) {
+        memset(vrf, '\0', sizeof(vrf));
+        memset(vlan, '\0', sizeof(vlan));
+        snprintf(vrf, sizeof(vrf), "vrf%d", id);
+        snprintf(vlan, sizeof(vlan), "br%d", id);
+
+        if (is_add == false) {
+            rc = nas_ut_intf_vrf_cfg(vrf,vlan,false);
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+            rc = nas_ut_vrf_cfg(vrf,false);
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip link delete %s.%d", b2b_intf1, id);
+            system(cmd);
+
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip link set dev %s down", vlan);
+            system(cmd);
+
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip link delete %s", vlan);
+            system(cmd);
+            continue;
+        }
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "brctl addbr %s", vlan);
+        system(cmd);
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s up", vlan);
+        system(cmd);
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link add link %s name %s.%d type vlan id %d",
+                 b2b_intf1, b2b_intf1, id, id);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "brctl addif %s %s.%d", vlan, b2b_intf1, id);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s.%d up", b2b_intf1, id);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s up", vlan);
+        system(cmd);
+
+        rc = nas_ut_vrf_cfg(vrf,true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_intf_vrf_cfg(vrf,vlan,true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip -n %s addr add 100.0.0.1/24 dev v-%s", vrf, vlan);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip -n %s neigh add 100.0.0.2 lladdr 00:11:22:33:44:55 dev v-%s", vrf, vlan);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip -n %s route add 60.0.0.0/8 via 100.0.0.2", vrf);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip -n %s addr add 100::1/64 dev v-%s", vrf, vlan);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip -n %s neigh add 100::2 lladdr 00:11:22:33:44:55 dev v-%s", vrf, vlan);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip -n %s -6 route add 60::/64 via 100::2", vrf);
+        system(cmd);
+    }
+    if (is_add) {
+        sleep(10);
+    }
+    for (id = start_vrf_id ;id < (start_vrf_id+no_of_vrfs); id++) {
+        memset(vrf, '\0', sizeof(vrf));
+        snprintf(vrf, sizeof(vrf), "vrf%d", id);
+        printf("\r\n VRF:%s is_add:%d", vrf, is_add);
+        rc = nas_ut_validate_rt_cfg (vrf, AF_INET, "100.0.0.1", 32, vrf, "", "", false);
+        ASSERT_TRUE(rc == rc_check);
+        rc = nas_ut_validate_rt_cfg (vrf, AF_INET, "100.0.0.0", 24, vrf, "", "", true);
+        ASSERT_TRUE(rc == rc_check);
+        rc = nas_ut_validate_neigh_cfg(vrf, AF_INET, "100.0.0.2", 128, true);
+        ASSERT_TRUE(rc == rc_check);
+        rc = nas_ut_validate_rt_cfg (vrf, AF_INET, "60.0.0.0", 8, vrf, "", "", true);
+        ASSERT_TRUE(rc == rc_check);
+        rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "100::1", 128, vrf, "", "", false);
+        ASSERT_TRUE(rc == rc_check);
+        rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "100::0", 64, vrf, "", "", true);
+        ASSERT_TRUE(rc == rc_check);
+        rc = nas_ut_validate_neigh_cfg(vrf, AF_INET6, "100::2", 128, true);
+        ASSERT_TRUE(rc == rc_check);
+        rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "60::0", 64, vrf, "", "", true);
+        ASSERT_TRUE(rc == rc_check);
+        rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "fe80::", 10, vrf, "", "", true);
+        ASSERT_TRUE(rc == rc_check);
+    }
+}
+
+static void nas_rt_scal_neigh_test(int start_vrf_id, int no_of_vrfs, int scal_arp_limit, int scal_neigh_limit,
+                                   bool is_add, cps_api_return_code_t rc_check, bool is_neg_test, bool fail_ok) {
+    char cmd [512];
+    char vrf[10];
+    char vlan[10];
+    int id, itr = 0;
+    cps_api_return_code_t rc;
+
+    /* Add/Del neighbors on the br1 in the default VRF */
+    for (itr = 2; itr <= (scal_arp_limit +1); itr++) {
+        if (is_neg_test == false) {
+            memset(cmd, '\0', sizeof(cmd));
+            if (is_add) {
+                snprintf(cmd, 511, "/usr/bin/cps_config_mac.py create mac 00:11:22:33:44:%02x port %s vlan 1 static", itr, b2b_intf1);
+            } else {
+                snprintf(cmd, 511, "/usr/bin/cps_config_mac.py delete vlan 1 port %s 00:11:22:33:44:%02x static", b2b_intf1, itr);
+            }
+            system(cmd);
+        }
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip neigh %s 100.0.0.%d lladdr 00:11:22:33:44:%02x dev br1",
+                 (is_add ? "add" : "del"), itr, itr);
+        system(cmd);
+        if (itr <= (scal_neigh_limit+1)) {
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip neigh %s 100::%x lladdr 00:11:22:33:44:%02x dev br1",
+                     (is_add ? "add" : "del"), itr, itr);
+            system(cmd);
+        }
+    }
+    for (id = start_vrf_id ;id < (start_vrf_id+no_of_vrfs); id++) {
+        memset(vrf, '\0', sizeof(vrf));
+        memset(vlan, '\0', sizeof(vlan));
+        snprintf(vrf, sizeof(vrf), "vrf%d", id);
+        snprintf(vlan, sizeof(vlan), "br%d", id);
+
+        if (is_add == false) {
+            if (is_neg_test == false) {
+                for (itr = 2; itr <= (scal_arp_limit +1); itr++) {
+                    memset(cmd, '\0', sizeof(cmd));
+                    snprintf(cmd, 511, "/opt/opx/bin/cps_config_mac.py delete vlan %d port %s 00:11:22:33:44:%02x static", id, b2b_intf1, itr);
+                    system(cmd);
+                }
+            }
+            rc = nas_ut_intf_vrf_cfg(vrf,vlan,false);
+            if (!fail_ok)
+                ASSERT_TRUE(rc == cps_api_ret_code_OK);
+            rc = nas_ut_vrf_cfg(vrf,false);
+            if (!fail_ok)
+                ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip link delete %s.%d", b2b_intf1, id);
+            system(cmd);
+
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip link set dev %s down", vlan);
+            system(cmd);
+
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip link delete %s", vlan);
+            system(cmd);
+            continue;
+        }
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "brctl addbr %s", vlan);
+        system(cmd);
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s up", vlan);
+        system(cmd);
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link add link %s name %s.%d type vlan id %d",
+                 b2b_intf1, b2b_intf1, id, id);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "brctl addif %s %s.%d", vlan, b2b_intf1, id);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s.%d up", b2b_intf1, id);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s up", vlan);
+        system(cmd);
+
+        rc = nas_ut_vrf_cfg(vrf,true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_intf_vrf_cfg(vrf,vlan,true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip -n %s addr add 100.0.0.1/24 dev v-%s", vrf, vlan);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip -n %s addr add 100::1/64 dev v-%s", vrf, vlan);
+        system(cmd);
+        for (itr = 2; itr <= (scal_arp_limit +1); itr++) {
+            if (is_neg_test == false) {
+                memset(cmd, '\0', sizeof(cmd));
+                snprintf(cmd, 511, "/usr/bin/cps_config_mac.py create mac 00:11:22:33:44:%02x port %s vlan %d static", itr, b2b_intf1, id);
+                system(cmd);
+            }
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip -n %s neigh add 100.0.0.%d lladdr 00:11:22:33:44:%02x dev v-%s",
+                     vrf, itr, itr, vlan);
+            system(cmd);
+            if (itr <= (scal_neigh_limit+1)) {
+                memset(cmd, '\0', sizeof(cmd));
+                snprintf(cmd, 511, "ip -n %s neigh add 100::%x lladdr 00:11:22:33:44:%02x dev v-%s",
+                         vrf, itr, itr, vlan);
+                system(cmd);
+            }
+        }
+    }
+    sleep(10);
+    char ip[64];
+    for (id = 1 ;id < (start_vrf_id+no_of_vrfs); id++) {
+        memset(vrf, '\0', sizeof(vrf));
+        if (id == 1) {
+            snprintf(vrf, sizeof(vrf), "default");
+            printf("\r\n VRF:%s is_add:%d", vrf, is_add);
+        } else {
+            snprintf(vrf, sizeof(vrf), "vrf%d", id);
+            printf("\r\n VRF:%s is_add:%d", vrf, is_add);
+        }
+        for (itr = 2; itr <= (scal_arp_limit +1); itr++) {
+            memset(ip, '\0', sizeof(ip));
+            snprintf(ip, sizeof(ip), "100.0.0.%d", itr);
+            rc = nas_ut_validate_neigh_cfg(vrf, AF_INET, ip, 128, true);
+            ASSERT_TRUE(rc == rc_check);
+            if (itr <= (scal_neigh_limit+1)) {
+                memset(ip, '\0', sizeof(ip));
+                snprintf(ip, sizeof(ip), "100::%x", itr);
+                rc = nas_ut_validate_neigh_cfg(vrf, AF_INET6, ip, 128, true);
+                ASSERT_TRUE(rc == rc_check);
+            }
+        }
+    }
+}
+
+static void nas_rt_cleanup() {
+    char cmd [512];
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip link set dev %s down", b2b_intf1);
+    system(cmd);
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip link set dev %s up", b2b_intf1);
+    system(cmd);
+
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip link set dev %s down", b2b_intf2);
+    system(cmd);
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip link set dev %s up", b2b_intf2);
+    system(cmd);
+}
+
+static void nas_rt_validate_blue_vrf_config(cps_api_return_code_t rc_check) {
+    cps_api_return_code_t rc;
+    sleep(5);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "30.0.0.0", 24, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "3333::0", 64, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "40.0.0.1", 32, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "4444::1", 128, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "50.0.0.0", 24, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "5555::0", 64, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET, "30.0.0.0", 24, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "3333::0", 64, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET, "50.0.0.1", 32, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "5555::1", 128, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET, "40.0.0.0", 24, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "4444::0", 64, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+
+    rc = nas_ut_validate_neigh_cfg("default", 2, "30.0.0.2", 2, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("default", 10, "3333::2", 2, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("blue", 2, "30.0.0.1", 2, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("blue", 10, "3333::1", 2, true);
+    ASSERT_TRUE(rc == rc_check);
+}
+
+static void nas_rt_validate_red_vrf_config(cps_api_return_code_t rc_check) {
+    cps_api_return_code_t rc;
+    sleep(5);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET, "30.0.0.0", 24, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "3333::0", 64, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET, "40.0.0.1", 32, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "4444::1", 128, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET, "50.0.0.0", 24, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "5555::0", 64, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+
+
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "30.0.0.0", 24, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "3333::0", 64, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "50.0.0.1", 32, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "5555::1", 128, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "40.0.0.0", 24, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "4444::0", 64, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+
+    rc = nas_ut_validate_neigh_cfg("red", 2, "30.0.0.2", 2, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("red", 10, "3333::2", 2, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("default", 2, "30.0.0.1", 2, true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("default", 10, "3333::1", 2, true);
+    ASSERT_TRUE(rc == rc_check);
+}
+
+static void nas_rt_basic_red_vrf_vlan_cfg(bool is_add) {
+    cps_api_return_code_t rc;
+    char cmd [512];
+
+    if (is_add == false) {
+        std::cout <<"********* Removing VRF with VLAN configurations *********"<<std::endl;
+        system("ip -n red addr del 30.0.0.1/24 dev v-br100");
+        system("ip -n red addr del 3333::1/64 dev v-br100");
+        system("ip -n red link del dev lo1");
+        rc = nas_ut_intf_vrf_cfg("red","br100",false);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_vrf_cfg("red",false);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "brctl delif br100 %s", b2b_intf1);
+        system(cmd);
+        system("ifconfig br100 down");
+        system("brctl delbr br100");
+
+        system("ip route del 40.0.0.0/24 via 30.0.0.1");
+        system("ip -6 route del 4444::/64 via 3333::1");
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip addr del 30.0.0.2/24 dev %s", b2b_intf2);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip addr del 3333::2/64 dev %s", b2b_intf2);
+        system(cmd);
+
+        system("ip link del dev lo2");
+        return;
+    }
+    std::cout <<"********* Adding VRF with VLAN configurations *********"<<std::endl;
+
+    system("brctl addbr br100");
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "brctl addif br100 %s", b2b_intf1);
+    system(cmd);
+    system("ip link set dev br100 up");
+    system("ip link add link e101-002-0 name e101-002-0.100 type vlan id 100");
+    system("brctl addif br100 e101-002-0.100");
+
+    rc = nas_ut_vrf_cfg("red",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_intf_vrf_cfg("red","br100",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    system("ip -n red addr add 30.0.0.1/24 dev v-br100");
+    system("ip -n red addr add  3333::1/64 dev v-br100");
+
+    system("ip -n red link add lo1 type dummy");
+    system("ip -n red link set dev lo1 up");
+    system("ip -n red addr add 40.0.0.1/32 dev lo1");
+    system("ip -n red addr add  4444::1/128 dev lo1");
+    system("ip -n red route add 50.0.0.0/24 via 30.0.0.2");
+    system("ip -n red -6 route add 5555::/64 via 3333::2");
+
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip addr add 30.0.0.2/24 dev %s", b2b_intf2);
+    system(cmd);
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip addr add 3333::2/64 dev %s", b2b_intf2);
+    system(cmd);
+
+    system("ip link add lo2 type dummy");
+    system("ip link set dev lo2 up");
+    system("ip addr add 50.0.0.1/32 dev lo2");
+    system("ip addr add  5555::1/128 dev lo2");
+    system("ip route add 40.0.0.0/24 via 30.0.0.1");
+    system("ip -6 route add 4444::/64 via 3333::1");
+}
+
+static void nas_rt_basic_blue_vrf_lag_cfg(bool is_add) {
+    cps_api_return_code_t rc;
+    char cmd [512];
+
+    if (is_add == false) {
+        std::cout <<"********* Removing VRF with LAG configurations *********"<<std::endl;
+        system("ip route del 50.0.0.0/24 via 30.0.0.2");
+        system("ip -6 route del 5555::/64 via 3333::2");
+        system("ip addr del 40.0.0.1/32 dev lo1");
+        system("ip addr del  4444::1/128 dev lo1");
+        system("ip link del lo1");
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip addr del 30.0.0.1/24 dev %s", b2b_intf1);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip addr del 3333::1/64 dev %s", b2b_intf1);
+        system(cmd);
+
+        rc = nas_ut_intf_vrf_cfg("blue","bo50",false);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_intf_vrf_cfg("blue","lo2",false);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_vrf_cfg("blue",false);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set %s nomaster", b2b_intf2);
+        system(cmd);
+        system("ip link del dev bo50");
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s up", b2b_intf2);
+        system(cmd);
+        system("ip link del lo2");
+        return;
+    }
+
+    std::cout <<"********* Adding VRF with LAG configurations *********"<<std::endl;
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip addr add 30.0.0.1/24 dev %s", b2b_intf1);
+    system(cmd);
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip addr add 3333::1/64 dev %s", b2b_intf1);
+    system(cmd);
+    system("ip link add lo1 type dummy");
+    system("ip link set dev lo1 up");
+    system("ip addr add 40.0.0.1/32 dev lo1");
+    system("ip addr add  4444::1/128 dev lo1");
+    system("ip route add 50.0.0.0/24 via 30.0.0.2");
+    system("ip -6 route add 5555::/64 via 3333::2");
+
+    system("ip link add bo50 type bond mode 1 miimon 100");
+    system("ip link set dev bo50 up");
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip link set dev %s down", b2b_intf2);
+    system(cmd);
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip link set %s master bo50", b2b_intf2);
+    system(cmd);
+    system("ifconfig bo50 up");
+
+    rc = nas_ut_vrf_cfg("blue",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    system("ip link add lo2 type dummy");
+    system("ip link set dev lo2 up");
+    rc = nas_ut_intf_vrf_cfg("blue","lo2",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_intf_vrf_cfg("blue","bo50",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    /* @@TODO This sleep is required today, since NAS-interface updates the intf-DB
+     * after getting the route update in NAS-L3 */
+    sleep(2);
+    system("ip -n blue addr add 30.0.0.2/24 dev v-bo50");
+    system("ip -n blue addr add  3333::2/64 dev v-bo50");
+    system("ip -n blue addr add 50.0.0.1/32 dev v-lo2");
+    system("ip -n blue addr add  5555::1/128 dev v-lo2");
+    system("ip -n blue route add 40.0.0.0/24 via 30.0.0.1");
+    system("ip -n blue -6 route add 4444::/64 via 3333::1");
+}
+
+static void nas_rt_basic_blue_vrf_phy_cfg(bool is_add) {
+    cps_api_return_code_t rc;
+    char cmd [512];
+
+    if (is_add == false) {
+        std::cout <<"********* Removing VRF with PHY configurations *********"<<std::endl;
+        nas_rt_special_next_hop_config(false, "blue");
+        rc = nas_ut_intf_vrf_cfg("blue",b2b_intf2,false);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_intf_vrf_cfg("blue","lo2",false);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_vrf_cfg("blue",false);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        system("ip link del lo2");
+
+        nas_ut_rt_cfg (NULL,0, "50.0.0.0", 24, AF_INET, NULL, "30.0.0.2", b2b_intf1);
+        nas_ut_rt_cfg ("default",0, "5555::", 64, AF_INET6, NULL, "3333::2", b2b_intf1);
+        system("ip addr del 40.0.0.1/32 dev lo1");
+        system("ip addr del  4444::1/128 dev lo1");
+        system("ip link del lo1");
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip addr del 30.0.0.1/24 dev %s", b2b_intf1);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip addr del 3333::1/64 dev %s", b2b_intf1);
+        system(cmd);
+
+        return;
+    }
+    std::cout <<"********* Adding VRF with PHY configurations *********"<<std::endl;
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip addr add 30.0.0.1/24 dev %s", b2b_intf1);
+    system(cmd);
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip addr add 3333::1/64 dev %s", b2b_intf1);
+    system(cmd);
+    system("ip link add lo1 type dummy");
+    system("ip link set dev lo1 up");
+    system("ip addr add 40.0.0.1/32 dev lo1");
+    system("ip addr add  4444::1/128 dev lo1");
+
+    nas_ut_rt_cfg (NULL,1, "50.0.0.0", 24, AF_INET, NULL, "30.0.0.2", b2b_intf1);
+    nas_ut_rt_cfg ("default",1, "5555::", 64, AF_INET6, NULL, "3333::2", b2b_intf1);
+
+    rc = nas_ut_vrf_cfg("blue",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_intf_vrf_cfg("blue",b2b_intf2,true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    system("ip link add lo2 type dummy");
+    system("ip link set dev lo2 up");
+    rc = nas_ut_intf_vrf_cfg("blue","lo2",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    /* @@TODO This sleep is required today, since NAS-interface updates the intf-DB
+     * after getting the route update in NAS-L3 */
+    sleep(2);
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip -n blue addr add 30.0.0.2/24 dev v-%s", b2b_intf2);
+    system(cmd);
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip -n blue addr add 3333::2/64 dev v-%s", b2b_intf2);
+    system(cmd);
+    system("ip -n blue addr add 50.0.0.1/32 dev v-lo2");
+    system("ip -n blue addr add  5555::1/128 dev v-lo2");
+    char rt_intf[15];
+    memset(rt_intf, '\0', sizeof(rt_intf));
+    snprintf(rt_intf, sizeof(rt_intf), "v-%s", b2b_intf2);
+
+    nas_ut_rt_cfg ("blue",1, "40.0.0.0", 24, AF_INET, NULL, "30.0.0.1", rt_intf);
+    nas_ut_rt_cfg ("blue",1, "4444::", 64, AF_INET6, "blue", "3333::1", rt_intf);
+
+    nas_rt_special_next_hop_config(true, "blue");
+}
+
+static void nas_rt_perf_test(int no_of_intfs, bool is_add) {
+    char cmd [512];
+    char vlan[10];
+    int id, start_intf_id = 2;
+    cps_api_return_code_t rc;
+
+    rc = nas_ut_vrf_cfg("blue", is_add);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    for (id = start_intf_id; id < (start_intf_id + no_of_intfs); id++) {
+        memset(vlan, '\0', sizeof(vlan));
+        snprintf(vlan, sizeof(vlan), "br%d", id);
+
+        if (is_add == false) {
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip link delete %s.%d", b2b_intf1, id);
+            system(cmd);
+
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip link set dev %s down", vlan);
+            system(cmd);
+
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip link delete %s", vlan);
+            system(cmd);
+            continue;
+        }
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "brctl addbr %s", vlan);
+        system(cmd);
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s up", vlan);
+        system(cmd);
+
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link add link %s name %s.%d type vlan id %d",
+                 b2b_intf1, b2b_intf1, id, id);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "brctl addif %s %s.%d", vlan, b2b_intf1, id);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s.%d up", b2b_intf1, id);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s up", vlan);
+        system(cmd);
+    }
+}
+
+
+TEST(nas_rt_vrf_test, nas_rt_basic_vlan_vrf) {
+    /* @@TODO Fix VLAN test case/ */
+    return;
+    nas_rt_basic_red_vrf_vlan_cfg(true);
+    nas_rt_validate_red_vrf_config(cps_api_ret_code_OK);
+    system("ip netns exec red ping -c 3 30.0.0.2");
+    system("ip netns exec red ping6 -c 3 3333::2");
+    system("ip netns exec red ping -c 3 50.0.0.1");
+    system("ip netns exec red ping6 -c 3 5555::1");
+    nas_rt_basic_red_vrf_vlan_cfg(false);
+    nas_rt_validate_red_vrf_config(cps_api_ret_code_ERR);
+    nas_rt_cleanup();
+}
+
+TEST(nas_rt_vrf_test, nas_rt_basic_lag_vrf) {
+    nas_rt_basic_blue_vrf_lag_cfg(true);
+    nas_rt_validate_blue_vrf_config(cps_api_ret_code_OK);
+    system("ping -c 3 30.0.0.2");
+    system("ping6 -c 3 3333::2");
+    system("ping -c 3 50.0.0.1");
+    system("ping6 -c 3 5555::1");
+    nas_rt_basic_blue_vrf_lag_cfg(false);
+    nas_rt_validate_blue_vrf_config(cps_api_ret_code_ERR);
+    nas_rt_cleanup();
+}
+
+TEST(nas_rt_vrf_test, nas_rt_basic_phy_vrf) {
+    char cmd [512];
+    uint32_t loop_cnt = 3;
+    while (loop_cnt--) {
+        printf("\r\n PHY config. loop:%d\r\n", loop_cnt);
+        nas_rt_basic_blue_vrf_phy_cfg(true);
+        nas_rt_special_next_hop_validate("blue", cps_api_ret_code_OK);
+
+        nas_rt_validate_blue_vrf_config(cps_api_ret_code_OK);
+        system("ping -c 3 30.0.0.2");
+        system("ping6 -c 3 3333::2");
+        system("ping -c 3 50.0.0.1");
+        system("ping6 -c 3 5555::1");
+
+        system("ip addr del 40.0.0.1/32 dev lo1");
+        system("ip addr del  4444::1/128 dev lo1");
+        system("ip -n blue addr del 50.0.0.1/32 dev v-lo2");
+        system("ip -n blue addr del  5555::1/128 dev v-lo2");
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s down", b2b_intf1);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip -n blue link set dev v-%s down", b2b_intf2);
+        system(cmd);
+        if (loop_cnt == 2) {
+            nas_rt_basic_blue_vrf_phy_cfg(false);
+            nas_rt_special_next_hop_validate("blue", cps_api_ret_code_ERR);
+            nas_rt_validate_blue_vrf_config(cps_api_ret_code_ERR);
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip link set dev %s up", b2b_intf1);
+            system(cmd);
+            continue;
+        }
+        nas_rt_basic_blue_vrf_phy_cfg(false);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s up", b2b_intf1);
+        system(cmd);
+        sleep(1);
+    }
+    nas_rt_special_next_hop_validate("blue", cps_api_ret_code_ERR);
+    nas_rt_validate_blue_vrf_config(cps_api_ret_code_ERR);
+    nas_rt_cleanup();
+}
+
+TEST(nas_rt_vrf_test, nas_rt_leak_route) {
+    cps_api_return_code_t rc;
+    char cmd [512];
+    uint32_t loop_cnt = 3;
+    while (loop_cnt--) {
+        printf("\r\n PHY config. loop:%d\r\n", loop_cnt);
+        nas_rt_basic_blue_vrf_phy_cfg(true);
+        nas_rt_special_next_hop_validate("blue", cps_api_ret_code_OK);
+        nas_rt_validate_blue_vrf_config(cps_api_ret_code_OK);
+
+        /* Leak 40.0.0.0/24 route from blue VRF to red VRF */
+        rc = nas_ut_vrf_cfg("red",true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        char rt_intf[15];
+        memset(rt_intf, '\0', sizeof(rt_intf));
+        snprintf(rt_intf, sizeof(rt_intf), "v-%s", b2b_intf2);
+        nas_ut_rt_cfg ("red",1, "40.0.0.0", 24, AF_INET, "blue", "30.0.0.1", rt_intf);
+        nas_ut_rt_cfg ("red",1, "4444::", 64, AF_INET6, "blue", "3333::1", rt_intf);
+        nas_ut_rt_cfg (NULL,1, "60.0.0.0", 24, AF_INET, "blue", "30.0.0.1", rt_intf);
+        nas_ut_rt_cfg ("default",1, "6666::", 64, AF_INET6, "blue", "3333::1", rt_intf);
+
+        /* Leak 50.0.0.0/24 route from default VRF to green VRF */
+        rc = nas_ut_vrf_cfg("green",true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        nas_ut_rt_cfg ("green",1, "50.0.0.0", 24, AF_INET, "default", "30.0.0.2", b2b_intf1);
+        nas_ut_rt_cfg ("green",1, "5555::", 64, AF_INET6, "default", "3333::2", b2b_intf1);
+        sleep(3);
+
+        rc = nas_ut_validate_rt_cfg ("red", AF_INET, "40.0.0.0", 24, "blue", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "4444::", 64, "blue", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_validate_rt_cfg ("default", AF_INET, "60.0.0.0", 24, "blue", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "6666::", 64, "blue", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_validate_rt_cfg ("green", AF_INET, "50.0.0.0", 24, "default", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_validate_rt_cfg ("green", AF_INET6, "5555::", 64, "default", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+        system("ping -c 3 30.0.0.2");
+        system("ping6 -c 3 3333::2");
+        system("ping -c 3 50.0.0.1");
+        system("ping6 -c 3 5555::1");
+        system("ip addr del 40.0.0.1/32 dev lo1");
+        system("ip addr del  4444::1/128 dev lo1");
+        system("ip -n blue addr del 50.0.0.1/32 dev v-lo2");
+        system("ip -n blue addr del  5555::1/128 dev v-lo2");
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s down", b2b_intf1);
+        system(cmd);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip -n blue link set dev v-%s down", b2b_intf2);
+        system(cmd);
+        nas_rt_special_next_hop_validate("blue", cps_api_ret_code_OK);
+        nas_rt_validate_blue_vrf_config(cps_api_ret_code_ERR);
+        sleep(3);
+        rc = nas_ut_validate_rt_cfg ("red", AF_INET, "40.0.0.0", 24, "blue", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+        rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "4444::", 64, "blue", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+        rc = nas_ut_validate_rt_cfg ("default", AF_INET, "60.0.0.0", 24, "blue", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+        rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "6666::", 64, "blue", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+        rc = nas_ut_validate_rt_cfg ("green", AF_INET, "50.0.0.0", 24, "default", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+        rc = nas_ut_validate_rt_cfg ("green", AF_INET6, "5555::", 64, "default", "", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+
+        nas_rt_basic_blue_vrf_phy_cfg(false);
+        rc = nas_ut_vrf_cfg("green",false);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_vrf_cfg("red",false);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        memset(cmd, '\0', sizeof(cmd));
+        snprintf(cmd, 511, "ip link set dev %s up", b2b_intf1);
+        system(cmd);
+    }
+    nas_rt_special_next_hop_validate("blue", cps_api_ret_code_ERR);
+    nas_rt_validate_blue_vrf_config(cps_api_ret_code_ERR);
+    nas_rt_cleanup();
+}
+
+TEST(nas_rt_vrf_test, nas_rt_scal_vrf) {
+    cps_api_return_code_t rc;
+    char vrf[10];
+    uint32_t id = 0, start_vrf_id = 2, scal_limit = 128, loop_cnt = 3;
+
+    nas_vrf_change_mode(false);
+    while (loop_cnt--) {
+        nas_rt_scal_test(start_vrf_id, scal_limit, true, cps_api_ret_code_OK);
+        /* Check that we cant go beyond allowed 1024 data VRFs */
+        //rc = nas_ut_vrf_cfg("blue",true);
+        //ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+        char vlan[10];
+
+        for (id = start_vrf_id ;id < (start_vrf_id+scal_limit); id++) {
+            memset(vrf, '\0', sizeof(vrf));
+            snprintf(vrf, sizeof(vrf), "vrf%d", id);
+            memset(vlan, '\0', sizeof(vlan));
+            snprintf(vlan, sizeof(vlan), "br%d", id);
+            char cmd [512];
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip -n %s link set dev v-%s down", vrf, vlan);
+            system(cmd);
+        }
+        if (loop_cnt == 1) {
+            nas_rt_scal_test(start_vrf_id, scal_limit, false, cps_api_ret_code_ERR);
+            continue;
+        }
+        sleep(10);
+        for (id = start_vrf_id ;id < (start_vrf_id+scal_limit); id++) {
+            memset(vrf, '\0', sizeof(vrf));
+            snprintf(vrf, sizeof(vrf), "vrf%d", id);
+            printf("\r\n VRF:%s route/nbr verification after admin down\r\n", vrf);
+            rc = nas_ut_validate_rt_cfg (vrf, AF_INET, "100.0.0.1", 32, vrf, "", "", false);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+            rc = nas_ut_validate_rt_cfg (vrf, AF_INET, "100.0.0.0", 24, vrf, "", "", true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+            rc = nas_ut_validate_neigh_cfg(vrf, AF_INET, "100.0.0.2", 128, true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+            rc = nas_ut_validate_rt_cfg (vrf, AF_INET, "60.0.0.0", 8, vrf, "", "", true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+            rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "100::1", 128, vrf, "", "", false);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+            rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "100::0", 64, vrf, "", "", true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+            rc = nas_ut_validate_neigh_cfg(vrf, AF_INET6, "100::2", 128, true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+            rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "60::0", 64, vrf, "", "", true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+            rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "fe80::", 10, vrf, "", "", true);
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        }
+
+        nas_rt_scal_test(start_vrf_id, scal_limit, false, cps_api_ret_code_ERR);
+    }
+}
+
+TEST(nas_rt_vrf_test, nas_rt_scal_neigh) {
+    char vrf[10];
+    uint32_t id = 0, start_vrf_id = 2, scal_limit = 10, loop_cnt = 3,
+             scal_arp_limit = 10, scal_neigh_limit = 5;
+    cps_api_return_code_t rc;
+
+    nas_vrf_change_mode(false);
+    while (loop_cnt--) {
+        nas_rt_scal_neigh_test(start_vrf_id, scal_limit, scal_arp_limit,
+                               scal_neigh_limit, true, cps_api_ret_code_OK, false, false);
+        printf("Bringing down all the interfaces");
+        system("ip link set dev br1 down");
+        char vlan[10];
+        for (id = start_vrf_id ;id < (start_vrf_id+scal_limit); id++) {
+            memset(vrf, '\0', sizeof(vrf));
+            snprintf(vrf, sizeof(vrf), "vrf%d", id);
+            memset(vlan, '\0', sizeof(vlan));
+            snprintf(vlan, sizeof(vlan), "br%d", id);
+            char cmd [512];
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip -n %s link set dev v-%s down", vrf, vlan);
+            system(cmd);
+            printf("\r\n Bring down interface:v-%s in VRF:%s", vlan, vrf);
+            if (loop_cnt == 2) {
+                printf("\r\n Delete VRF:%s", vrf);
+                rc = nas_ut_vrf_cfg(vrf,false);
+                ASSERT_TRUE(rc == cps_api_ret_code_OK);
+            }
+        }
+
+        nas_rt_scal_neigh_test(start_vrf_id, scal_limit, scal_arp_limit, scal_neigh_limit,
+                               false, cps_api_ret_code_ERR, false, ((loop_cnt == 2) ? true : false));
+        system("ip link set dev br1 up");
+    }
+}
+
+
+TEST(nas_rt_vrf_test, nas_rt_scal_neigh_neg_test) {
+    char vrf[10];
+    uint32_t id = 0, start_vrf_id = 2, scal_limit = 10, loop_cnt = 2,
+             scal_arp_limit = 10, scal_neigh_limit = 5;
+
+    nas_vrf_change_mode(false);
+    while (loop_cnt--) {
+        nas_rt_scal_neigh_test(start_vrf_id, scal_limit, scal_arp_limit,
+                               scal_neigh_limit, true, cps_api_ret_code_OK, true, false);
+        nas_rt_scal_neigh_test(start_vrf_id, scal_limit, scal_arp_limit, scal_neigh_limit,
+                               false, cps_api_ret_code_ERR, true, false);
+        system("ip link set dev br1 down");
+        char vlan[10];
+        for (id = start_vrf_id ;id < (start_vrf_id+scal_limit); id++) {
+            memset(vrf, '\0', sizeof(vrf));
+            snprintf(vrf, sizeof(vrf), "vrf%d", id);
+            memset(vlan, '\0', sizeof(vlan));
+            snprintf(vlan, sizeof(vlan), "br%d", id);
+            char cmd [512];
+            memset(cmd, '\0', sizeof(cmd));
+            snprintf(cmd, 511, "ip -n %s link set dev v-%s down", vrf, vlan);
+            system(cmd);
+        }
+
+        nas_rt_scal_neigh_test(start_vrf_id, scal_limit, scal_arp_limit, scal_neigh_limit,
+                               false, cps_api_ret_code_ERR, true, true);
+        system("ip link set dev br1 up");
+    }
+}
+
+TEST(nas_rt_vrf_test, nas_rt_perf_vrf) {
+    cps_api_return_code_t rc;
+    uint32_t no_of_intfs = 128;
+    uint32_t id, start_intf_id = 2;
+    char vlan[10];
+
+    nas_vrf_change_mode(false);
+    nas_rt_perf_test (no_of_intfs, true);
+
+    char  start_time[50], end_time[50];
+    int start_sec = 0, end_sec = 0, start_milli_sec = 0, end_milli_sec = 0;
+    print_time(start_time, &start_sec, &start_milli_sec);
+
+    for (id = start_intf_id; id < (start_intf_id + no_of_intfs); id++) {
+        memset(vlan, '\0', sizeof(vlan));
+        snprintf(vlan, sizeof(vlan), "br%d", id);
+        rc = nas_ut_intf_vrf_cfg("blue", vlan, true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    }
+
+    print_time(end_time, &end_sec, &end_milli_sec);
+    printf("\r\n Time taken start-time:%s end-time:%s diff-sec:%d diff-ms:%d "
+           "for association %d interface to blue VRF", start_time, end_time,
+           (end_sec-start_sec), (end_milli_sec-start_milli_sec), no_of_intfs);
+    for (id = start_intf_id; id < (start_intf_id + no_of_intfs); id++) {
+        memset(vlan, '\0', sizeof(vlan));
+        snprintf(vlan, sizeof(vlan), "br%d", id);
+        rc = nas_ut_intf_vrf_cfg("blue", vlan, false);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    }
+    nas_rt_perf_test (no_of_intfs, false);
+
+}
+
+TEST(nas_rt_vrf_test, nas_rt_mgmt_vrf) {
+    cps_api_return_code_t rc;
+    rc = nas_ut_vrf_cfg("management",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_intf_mgmt_vrf_cfg("management","eth0",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    nas_ut_rt_cfg ("management",1, "50.0.0.0", 24, AF_INET, NULL, NULL, "eth0");
+    nas_ut_rt_cfg ("management",1, "5555::", 64, AF_INET6, NULL, NULL, "eth0");
+    sleep(2);
+    rc = nas_ut_validate_rt_cfg ("management", AF_INET, "50.0.0.0", 24, NULL, NULL, NULL, false);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_validate_rt_cfg ("management", AF_INET6, "5555::", 64, NULL, NULL, NULL, false);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_intf_mgmt_vrf_cfg("management","eth0",false);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_vrf_cfg("management",false);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    sleep(2);
+    rc = nas_ut_validate_rt_cfg ("management", AF_INET, "50.0.0.0", 24, NULL, NULL, NULL, false);
+    ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+    rc = nas_ut_validate_rt_cfg ("management", AF_INET6, "5555::", 64, NULL, NULL, NULL, false);
+    ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+    rc = nas_ut_intf_mgmt_vrf_cfg("management","eth0",false);
+    ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+    rc = nas_ut_vrf_cfg("management",false);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+}
+
+TEST(nas_rt_vrf_test, nas_rt_vrf_special_nh_route) {
+    cps_api_return_code_t rc;
+    rc = nas_ut_vrf_cfg("blue",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    nas_rt_special_next_hop_config(true, "blue");
+    nas_rt_special_next_hop_validate("blue", cps_api_ret_code_OK);
+
+    rc = nas_ut_vrf_cfg("blue",false);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    nas_rt_special_next_hop_validate("blue", cps_api_ret_code_ERR);
+}
+
+TEST(nas_rt_vrf_test, nas_rt_vrf_neg_test) {
+    cps_api_return_code_t rc;
+    /* Reset the port-configs */
+    nas_vrf_change_mode(false);
+    /* Negative test to make sure L2 interface is not getting associated with VRF */
+    rc = nas_ut_vrf_cfg("blue",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_intf_vrf_cfg("blue",b2b_intf2,true);
+    ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+
+    /* configure the test pre-requisite */
+    nas_vrf_change_mode(true);
+
+    rc = nas_ut_intf_vrf_cfg("blue",b2b_intf2,true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    rc = nas_ut_vrf_cfg("red",true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    /* Verify that L3 interface is not associated with more than
+     * one VRF any point in time */
+    rc = nas_ut_intf_vrf_cfg("red",b2b_intf2,true);
+    ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+
+    rc = nas_ut_intf_vrf_cfg("blue",b2b_intf2,false);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_vrf_cfg("blue",false);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_vrf_cfg("red",false);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+}
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+
+    /* configure the test pre-requisite */
+    nas_vrf_change_mode(true);
+
+    printf("___________________________________________\n");
+
+    return(RUN_ALL_TESTS());
+}
+

--- a/src/unit_test/run_test
+++ b/src/unit_test/run_test
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+./hal_rt_dr_unittest
+./nas_rt_offload_cps_unittest
+./nas_route_cps_unittest
+./virtual_routing_ip_cfg_test.py run-test
+./nas_rt_vrf_unittest
+./ip_redirect_cfg_test.py run-test

--- a/src/unit_test/virtual_routing_ip_cfg_test.py
+++ b/src/unit_test/virtual_routing_ip_cfg_test.py
@@ -1,0 +1,270 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+# LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+# FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+
+import cps
+from cps_utils import *
+import sys
+import subprocess
+
+config_data = {
+1: {'vrf-name':'default', 'af':10, 'ifname':'br100', 'ip':'fe8000000000000092b11cfffef49cc1'},
+2: {'vrf-name':'default', 'af':10, 'ifname':'br110', 'ip':'fe8000000000000092b11cfffef49cc1'},
+3: {'vrf-name':'default', 'af':10, 'ifname':'e101-015-0', 'ip':'fe8000000000000092b11cfffef49c8a'},
+}
+
+fail_data = {
+1: {'vrf-name':'default', 'af':10, 'ifname':'br100', 'ip':'111100000000000092b11cfffef49cc1'},
+2: {'vrf-name':'default', 'af':10, 'ifname':'e101-015-0', 'ip':'222200000000000092b11cfffef49c8a'},
+}
+
+def commit(obj, op):
+    l = []
+    obj_tup = (op, obj.get())
+    l.append(obj_tup)
+    t = CPSTransaction(l)
+    ret = t.commit()
+    if ret:
+        print "Commit success"
+    return ret
+
+
+def usage():
+    print"\n nas_rt_cps_virt_routing_ip_unittest.py run-test"
+    print"\n nas_rt_cps_virt_routing_ip_unittest.py create vrf <name> af <af>] ifname <name> ip <address>"
+    print" nas_rt_cps_virt_routing_ip_unittest.py delete vrf <name> af <af>] ifname <name> ip <address>"
+    print" nas_rt_cps_virt_routing_ip_unittest.py show [vrf <name>] [af <af>] [ifname <name>] [ip <address>]"
+    print"\n"
+
+
+def exec_shell(cmd):
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    (out, err) = proc.communicate()
+    #print out
+    return out
+
+
+def handle_config(op, vrf, af, ifname, ip):
+    #print(" vrf:", vrf)
+    #print(" af:", af)
+    #print(" ifname:", ifname)
+    #print(" ip:", ip)
+    obj = CPSObject('base-route/virtual-routing-config/virtual-routing-ip-config',
+                     data= {"vrf-name" : vrf, "af" : af,
+                       "ifname" : ifname,  "ip" : ip,  })
+    ret = commit(obj, op)
+    return ret
+
+
+
+def handle_get(vrf, af, ifname, ip):
+    get_list = []
+    get_obj = CPSObject("base-route/virtual-routing-config/virtual-routing-ip-config")
+    if vrf is not None:
+        get_obj.add_attr("vrf-name", vrf)
+    if (af != 0):
+        get_obj.add_attr("af", af)
+    if ifname is not None:
+        get_obj.add_attr("ifname", ifname)
+    if ip is not None:
+        get_obj.add_attr("ip", ip)
+    if cps.get([get_obj.get()], get_list):
+        if not get_list:
+            get_list = None
+        return get_list
+    else:
+        return None
+
+def handle_show(vrf, af, ifname, ip):
+    get_list = handle_get(vrf, af, ifname, ip)
+    if get_list is not None:
+        for i in get_list:
+            print_obj(i)
+    else:
+        print("\n no objects received")
+
+def test_pre_req_cfg():
+    #print("Test pre requisite config")
+    mode = 'OPX'
+    ret = exec_shell('opx-show-version | grep \"OS_NAME.*Enterprise\"')
+    if ret:
+        mode = 'DoD'
+
+    if mode is 'DoD':
+        #configure via CLI the test pre requisites
+        cmd_list =  ['configure terminal',
+                     'interface ethernet 1/1/15',
+                     'no switchport',
+                     'ip address 15.1.1.1/24',
+                     'exit',
+                     'interface vlan 100',
+                     'ip address 100.1.1.1/24',
+                     'exit',
+                     'interface vlan 110',
+                     'ip address 110.1.1.1/24',
+                     'exit',
+                     'interface range ethernet 1/1/9,1/1/19',
+                     'switchport mode trunk',
+                     'switchport trunk allowed vlan 100,110',
+                     'exit']
+        cfg_file = open('/tmp/test_pre_req', 'w')
+        for item in cmd_list:
+            print>>cfg_file, item
+        cfg_file.close()
+        exec_shell('sudo -u admin clish --b /tmp/test_pre_req')
+    else:
+        #configure via linux commands the test pre requisites
+        exec_shell('brctl addbr br100 up')
+        exec_shell('ifconfig br100 down')
+        exec_shell('ip link add link e101-009-0 name e101-009-0.100 type vlan id 100')
+        exec_shell('ip link add link e101-019-0 name e101-019-0.100 type vlan id 100')
+        exec_shell('ifconfig e101-009-0 up')
+        exec_shell('ifconfig e101-019-0 up')
+        exec_shell('ip link set dev e101-009-0.100 up')
+        exec_shell('ip link set dev e101-019-0.100 up')
+        exec_shell('brctl addif br100 e101-009-0.100')
+        exec_shell('brctl addif br100 e101-019-0.100')
+        exec_shell('ip addr add 100.1.1.1/24 dev br100')
+        exec_shell('ip addr add  100:1::1/64 dev br100')
+        exec_shell('ifconfig br100 up')
+        exec_shell('brctl stp br100 on')
+
+        exec_shell('brctl addbr br110 up')
+        exec_shell('ifconfig br110 down')
+        exec_shell('ip link add link e101-009-0 name e101-009-0.110 type vlan id 110')
+        exec_shell('ip link add link e101-019-0 name e101-019-0.110 type vlan id 110')
+        exec_shell('ifconfig e101-009-0 up')
+        exec_shell('ifconfig e101-019-0 up')
+        exec_shell('ip link set dev e101-009-0.110 up')
+        exec_shell('ip link set dev e101-019-0.110 up')
+        exec_shell('brctl addif br100 e101-009-0.110')
+        exec_shell('brctl addif br100 e101-019-0.110')
+        exec_shell('ip addr add 110.1.1.1/24 dev br110')
+        exec_shell('ip addr add  110:1::1/64 dev br110')
+        exec_shell('ifconfig br110 up')
+        exec_shell('brctl stp br110 on')
+
+        exec_shell('ifconfig e101-015-0 up')
+        exec_shell('ip addr add 15.1.1.1/24 dev e101-015-0')
+        exec_shell('ip addr add 15:1::1/64 dev e101-015-0')
+
+
+if __name__ == '__main__':
+    vrf = None
+    af = 0
+    show = 0
+    delete = 0
+    create = 0
+    ifname = None
+    ip = None
+    mac = ""
+    ret = 0
+    if len(sys.argv) == 1:
+        usage()
+    else:
+        if (sys.argv[1] in ["show", "create", "delete"]):
+            print("len = ", len(sys.argv))
+            print("command : ", sys.argv[1])
+            arglen = len(sys.argv)
+            if (sys.argv[1] == "show"):
+                show = 1
+            elif (sys.argv[1] == "delete"):
+                delete = 1
+            elif (sys.argv[1] == "create"):
+                create = 1
+            i = 2
+            while (i < arglen):
+                print("\n iteration i", i)
+                if (sys.argv[i] == "vrf"):
+                    i = i + 1
+                    if (i > arglen):
+                        print"\n\n Please reenter vrf-name"
+                    vrf = sys.argv[i]
+                elif (sys.argv[i] == "af"):
+                    i = i + 1
+                    if (i > arglen):
+                        print"\n\n please reenter with af"
+                    af = sys.argv[i]
+                elif (sys.argv[i] == "ifname"):
+                    i = i + 1
+                    if (i > arglen):
+                        print"\n\n please enter ifname"
+                    ifname = sys.argv[i]
+                elif (sys.argv[i] == "ip"):
+                    i = i + 1
+                    if (i > arglen):
+                        print"\n\n please enter ip in hex format ('fe8000000000000092b11cfffef49cc1')"
+                    ip = sys.argv[i]
+                i = i + 1
+            print(
+                "\n\n cmd with vrf, af, ifname, ip ",
+                vrf,
+                af,
+                ifname,
+                ip)
+            if (show):
+                handle_show(
+                    vrf,
+                    af,
+                    ifname,
+                    ip)
+            elif (delete):
+                handle_config(
+                    "delete",
+                    vrf,
+                    af,
+                    ifname,
+                    ip)
+            elif (create):
+                handle_config(
+                    "create",
+                    vrf,
+                    af,
+                    ifname,
+                    ip)
+        elif (sys.argv[1] in ["run-test"]):
+            test_pre_req_cfg()
+            i = 1
+            while(i<=3):
+                entry = config_data[i]
+                if not handle_config("create", entry['vrf-name'], entry['af'], entry['ifname'], entry['ip']):
+                    ret = 1
+                if handle_get(entry['vrf-name'], entry['af'], entry['ifname'], entry['ip']) is None:
+                    ret = 1
+                i+=1
+            i = 1
+            while(i<=3):
+                entry = config_data[i]
+                if not handle_config("delete", entry['vrf-name'], entry['af'], entry['ifname'], entry['ip']):
+                    ret = 1
+                if handle_get(entry['vrf-name'], entry['af'], entry['ifname'], entry['ip']) is not None:
+                    ret = 1
+                i+=1
+            i = 1
+            while(i<=3):
+                entry = config_data[i]
+                if handle_get(entry['vrf-name'], entry['af'], entry['ifname'], entry['ip']) is not None:
+                    ret = 1
+                i+=1
+            i = 1
+            while(i<=2):
+                entry = fail_data[i]
+                if handle_config("create", entry['vrf-name'], entry['af'], entry['ifname'], entry['ip']):
+                    ret = 1
+                if handle_get(entry['vrf-name'], entry['af'], entry['ifname'], entry['ip']) is not None:
+                    ret = 1
+                i+=1
+        else:
+            usage()
+    sys.exit(ret)


### PR DESCRIPTION
* Feature: Routing VRF
* Update: ICMP Redirect support
* Update: Data VRF support in NAS-l3
* Update: Program loopback address in NPU
* Update: Added support for virtual routing IP configuration to configure peer's link local
          address in hardware.
* Bugfix: Update the mgmt route status when the default route with eth0 is getting replaced
          with default route with null interface.

Signed-off-by: Garrick He <garrick_he@dell.com>