### PR TITLE
opx-nas-l3 sync - 3.0.0-dev2

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-l3], [3.6.0], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-l3], [3.9.0], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,14 +1,10 @@
 opx-nas-l3 (3.9.0) unstable; urgency=medium
 
   * Update: Added UT script for PBR ACL cleanup dependency issue
-  * Bugfix: 'show ip arp summary' and 'ipv6 neighbor summary' do not clear the 
-            count on shutting down the ICL ports.
-  * Bugfix: arp mismatch is seen between vlt peers after a node reload on a TOR switch.
   * Update: NHT support for non-default VRF.
   * Update: Added support for virtual rif attribute as part of VRRP peer routing MAC configuration.
   * Update: Updated NHT UT scripts to use the logs for validation based on test start time.
   * Bugfix: VLAN LLA missing from "l3 ip6host show" table resulting in failure to learn IPv6 host entries via traffic
-  * Bugfix: Missing arp entries on vlt peer
   * Bugfix: show ip arp vrf displaying stale entries after deleting the vrf vlan
   * Update: Handle the RIF creation when the local interface DB is not populated.
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,19 @@
+opx-nas-l3 (3.9.0) unstable; urgency=medium
+
+  * Update: Added UT script for PBR ACL cleanup dependency issue
+  * Bugfix: 'show ip arp summary' and 'ipv6 neighbor summary' do not clear the 
+            count on shutting down the ICL ports.
+  * Bugfix: arp mismatch is seen between vlt peers after a node reload on a TOR switch.
+  * Update: NHT support for non-default VRF.
+  * Update: Added support for virtual rif attribute as part of VRRP peer routing MAC configuration.
+  * Update: Updated NHT UT scripts to use the logs for validation based on test start time.
+  * Bugfix: VLAN LLA missing from "l3 ip6host show" table resulting in failure to learn IPv6 host entries via traffic
+  * Bugfix: Missing arp entries on vlt peer
+  * Bugfix: show ip arp vrf displaying stale entries after deleting the vrf vlan
+  * Update: Handle the RIF creation when the local interface DB is not populated.
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Fri, 25 May 2018 15:00:00 -0800
+
 opx-nas-l3 (3.6.0) unstable; urgency=medium
 
   * Feature: Routing VRF

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Dell EMC <ops-dev@lists.openswitch.net>
 Build-Depends: debhelper (>= 9),dh-autoreconf,dh-systemd,autotools-dev,libopx-common-dev (>= 1.4.0),
                libopx-nas-common-dev (>= 6.1.0),libopx-cps-dev (>= 3.6.2),libopx-logging-dev (>= 2.1.0),
-               libopx-nas-linux-dev (>= 5.11.0),libopx-nas-ndi-dev (>= 3.26.0),opx-ndi-api-dev (>= 6.12.0),
+               libopx-nas-linux-dev (>= 5.11.0),libopx-nas-ndi-dev (>= 4.6.0),opx-ndi-api-dev (>= 7.5.0),
                libssl-dev,libsystemd-dev
 Standards-Version: 3.9.3
 Vcs-Browser: https://github.com/open-switch/opx-nas-l3
@@ -13,14 +13,14 @@ Vcs-Git: https://github.com/open-switch/opx-nas-l3.git
 Package: libopx-nas-l3-1
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},libopx-nas-common1 (>= 6.1.0),libopx-common1 (>= 1.4.0),libopx-cps1 (>= 3.6.2),
-        libopx-logging1 (>= 2.1.0),libopx-nas-linux1 (>= 5.11.0),libopx-nas-ndi1 (>= 3.26.0)
+        libopx-logging1 (>= 2.1.0),libopx-nas-linux1 (>= 5.11.0),libopx-nas-ndi1 (>= 4.6.0)
 Description: This package contains base layer 3 functionality for the Openswitch software.
 
 Package: libopx-nas-l3-dev
 Architecture: any
 Depends: ${misc:Depends},libopx-common-dev (>= 1.4.0),libopx-nas-common-dev (>= 6.1.0),
          libopx-cps-dev (>= 3.6.2),libopx-logging-dev (>= 2.1.0),libopx-nas-linux-dev (>= 5.11.0),
-         libopx-nas-ndi-dev (>= 3.26.0),opx-ndi-api-dev (>= 6.12.0),libopx-nas-l3-1 (=${binary:Version}),
+         libopx-nas-ndi-dev (>= 4.6.0),opx-ndi-api-dev (>= 7.5.0),libopx-nas-l3-1 (=${binary:Version}),
          libopx-base-model-dev (>= 3.109.0)
 Description: This package contains base layer 3 functionality for the Openswitch software.
 

--- a/inc/opx/hal_rt_util.h
+++ b/inc/opx/hal_rt_util.h
@@ -165,5 +165,6 @@ bool hal_rt_form_neigh_flush_msg (t_fib_offload_msg *p_offload_msg, t_fib_dr *p_
 int nas_rt_process_offload_msg(t_fib_offload_msg *p_offload_msg);
 int fib_offload_msg_main(void);
 bool hal_rt_is_vrf_valid(hal_vrf_id_t vrf_id);
+t_std_error fib_process_pending_resolve_dr(int vrf_id, int af_index);
 #endif /* __HAL_RT_UTIL_H__ */
 

--- a/inc/opx/nas_rt_api.h
+++ b/inc/opx/nas_rt_api.h
@@ -139,7 +139,7 @@ int nas_rt_publish_nht(t_fib_nht *p_nht, t_fib_dr *p_dr, t_fib_nh *p_nh, bool is
 t_fib_nht *fib_get_nht (uint32_t vrf_id, t_fib_ip_addr *p_dest_addr);
 t_fib_nht *fib_get_first_nht (uint32_t vrf_id, uint8_t af_index);
 t_fib_nht *fib_get_next_nht (uint32_t vrf_id, t_fib_ip_addr *p_dest_addr);
-t_std_error nas_route_get_all_nht_info(cps_api_object_list_t list, unsigned int vrf_id,
+t_std_error nas_route_get_all_nht_info(cps_api_object_list_t list, bool is_specific_vrf_get, unsigned int vrf_id,
                                        unsigned int af, t_fib_ip_addr *p_dest_addr);
 t_std_error nas_route_get_all_route_info(cps_api_object_list_t list, uint32_t vrf_id, uint32_t af,
                                          hal_ip_addr_t *p_prefix, uint32_t pref_len, bool is_specific_prefix_get,

--- a/inc/opx/nbr-mgr/nbr_mgr_cache.h
+++ b/inc/opx/nbr-mgr/nbr_mgr_cache.h
@@ -118,6 +118,10 @@ typedef struct {
     uint32_t flush_refresh;
     uint32_t mac_trig_refresh;
     uint32_t npu_prg_msg_cnt;
+    uint32_t mac_add_trig_refresh;
+    uint32_t mac_add_trig_resolve;
+    uint32_t delay_trig_refresh;
+    uint32_t delay_resolve_cnt;
 }nbr_mgr_nbr_stats;
 
 typedef struct {
@@ -279,6 +283,7 @@ public:
     bool trigger_resolve() const;
     bool trigger_refresh() const;
     bool trigger_delay_refresh() const;
+    bool trigger_delay_resolve() const;
     bool trigger_refresh_for_mac_learn() const;
     bool publish_entry(nbr_mgr_op_t op, const nbr_mgr_nbr_entry_t&) const;
     void populate_nbr_entry(nbr_mgr_nbr_entry_t& entry) const;

--- a/inc/opx/nbr-mgr/nbr_mgr_main.h
+++ b/inc/opx/nbr-mgr/nbr_mgr_main.h
@@ -36,7 +36,8 @@
 #define NBR_MGR_NUD_NONE          0x00
 
 #define NBR_MGR_BURST_RESOLVE_CNT 300
-#define NBR_MGR_MAX_NBR_RETRY_CNT 10
+#define NBR_MGR_MIN_NBR_RETRY_CNT 10
+#define NBR_MGR_MAX_NBR_RETRY_CNT 25
 #define NBR_MGR_MAX_NBR_REFRESH_MAC_LEARN_RETRY_CNT 100
 #define NBR_MGR_BURST_RESOLVE_DELAY 1 /* Every 1 sec NBR_MGR_BURST_RESOLVE_CNT ARP
                                          messages will be sent from kernel */

--- a/inc/opx/nbr-mgr/nbr_mgr_msgq.h
+++ b/inc/opx/nbr-mgr/nbr_mgr_msgq.h
@@ -48,7 +48,8 @@ typedef enum {
     NBR_MGR_NL_REFRESH_MSG,
     NBR_MGR_NAS_FLUSH_MSG,
     NBR_MGR_NL_DELAY_REFRESH_MSG,
-    NBR_MGR_DUMP_MSG
+    NBR_MGR_DUMP_MSG,
+    NBR_MGR_NL_DELAY_RESOLVE_MSG
 } nbr_mgr_msg_type_t;
 
 typedef enum {

--- a/nbr-mgr/src/nbr_mgr_debug.cpp
+++ b/nbr-mgr/src/nbr_mgr_debug.cpp
@@ -41,35 +41,40 @@ void nbr_process::nbr_mgr_dump_process_stats() {
 }
 
 static void _nbr_mgr_dump_nbr_data_stats(nbr_data const * ptr) {
-    NBR_MGR_LOG_ERR("DUMP", "Neighbor STATS vrf-id:%d Nbr:%s refresh:%d delay refresh:%d resolve:%d "
-                    "retry:%d mac_np:%d fail_trig:%d stale_ref:%d hw_mac_lrn_refresh:%d mac_trig_ref:%d "
-                    "FLUSH skip:%d fail_resolve:%d refresh:%d",
+    NBR_MGR_LOG_ERR("DUMP", "Neighbor STATS vrf-id:%d Nbr:%s refresh:%d delay refresh:%d delay resolve:%d resolve:%d "
+                    "retry:%d mac_np:%d fail_trig_resolve:%d stale_ref:%d hw_mac_lrn_refresh:%d mac_trig_ref:%d "
+                    "FLUSH skip:%d fail_resolve:%d refresh:%d mac add resolve:%d refresh:%d delay-state-failed-resolve:%d",
                     ptr->get_vrf_id(), ptr->get_ip_addr().c_str(),
-                    ptr->nbr_stats.refresh_cnt, ptr->nbr_stats.delay_refresh_cnt, ptr->nbr_stats.resolve_cnt,
+                    ptr->nbr_stats.refresh_cnt, ptr->nbr_stats.delay_refresh_cnt,
+                    ptr->nbr_stats.delay_resolve_cnt, ptr->nbr_stats.resolve_cnt,
                     ptr->nbr_stats.retry_cnt, ptr->nbr_stats.mac_not_present_cnt,
                     ptr->nbr_stats.failed_trig_resolve_cnt, ptr->nbr_stats.stale_trig_refresh_cnt,
                     ptr->nbr_stats.hw_mac_learn_refresh_cnt, ptr->nbr_stats.mac_trig_refresh,
                     ptr->nbr_stats.flush_skip_refresh, ptr->nbr_stats.flush_failed_resolve,
-                    ptr->nbr_stats.flush_refresh);
+                    ptr->nbr_stats.flush_refresh, ptr->nbr_stats.mac_add_trig_resolve,
+                    ptr->nbr_stats.mac_add_trig_refresh, ptr->nbr_stats.delay_trig_refresh);
 }
 
 static void _nbr_mgr_dump_nbr_data_ref_stats(nbr_data_ptr &ptr) {
-    NBR_MGR_LOG_ERR("DUMP", "Neighbor STATS vrf-id:%d Nbr:%s refresh:%d delay refresh:%d resolve:%d "
-                    "retry:%d mac_np:%d fail_trig:%d stale_ref:%d hw_mac_lrn_refresh:%d mac_trig_ref:%d "
-                    "FLUSH skip:%d fail_resolve:%d refresh:%d",
+    NBR_MGR_LOG_ERR("DUMP", "Neighbor STATS vrf-id:%d Nbr:%s refresh:%d delay refresh:%d delay resolve:%d resolve:%d "
+                    "retry:%d mac_np:%d fail_trig_resolve:%d stale_ref:%d hw_mac_lrn_refresh:%d mac_trig_ref:%d "
+                    "FLUSH skip:%d fail_resolve:%d refresh:%d mac add resolve:%d refresh:%d delay-state-failed-resolve:%d",
                     ptr->get_vrf_id(), ptr->get_ip_addr().c_str(),
-                    ptr->nbr_stats.refresh_cnt, ptr->nbr_stats.delay_refresh_cnt, ptr->nbr_stats.resolve_cnt,
+                    ptr->nbr_stats.refresh_cnt, ptr->nbr_stats.delay_refresh_cnt,
+                    ptr->nbr_stats.delay_resolve_cnt, ptr->nbr_stats.resolve_cnt,
                     ptr->nbr_stats.retry_cnt, ptr->nbr_stats.mac_not_present_cnt,
                     ptr->nbr_stats.failed_trig_resolve_cnt, ptr->nbr_stats.stale_trig_refresh_cnt,
                     ptr->nbr_stats.hw_mac_learn_refresh_cnt, ptr->nbr_stats.mac_trig_refresh,
                     ptr->nbr_stats.flush_skip_refresh, ptr->nbr_stats.flush_failed_resolve,
-                    ptr->nbr_stats.flush_refresh);
+                    ptr->nbr_stats.flush_refresh, ptr->nbr_stats.mac_add_trig_resolve,
+                    ptr->nbr_stats.mac_add_trig_refresh, ptr->nbr_stats.delay_trig_refresh);
 }
 
 static nbr_mgr_nbr_stats gbl_nbr_stats;
 static void nbr_mgr_dump_all_nbr_data_stats(nbr_data const * ptr) {
     gbl_nbr_stats.refresh_cnt += ptr->nbr_stats.refresh_cnt;
     gbl_nbr_stats.delay_refresh_cnt += ptr->nbr_stats.delay_refresh_cnt;
+    gbl_nbr_stats.delay_resolve_cnt += ptr->nbr_stats.delay_resolve_cnt;
     gbl_nbr_stats.resolve_cnt += ptr->nbr_stats.resolve_cnt;
     gbl_nbr_stats.retry_cnt += ptr->nbr_stats.retry_cnt;
     gbl_nbr_stats.mac_not_present_cnt += ptr->nbr_stats.mac_not_present_cnt;
@@ -80,21 +85,23 @@ static void nbr_mgr_dump_all_nbr_data_stats(nbr_data const * ptr) {
     gbl_nbr_stats.flush_skip_refresh += ptr->nbr_stats.flush_skip_refresh;
     gbl_nbr_stats.flush_failed_resolve += ptr->nbr_stats.flush_failed_resolve;
     gbl_nbr_stats.flush_refresh += ptr->nbr_stats.flush_refresh;
+    gbl_nbr_stats.delay_trig_refresh += ptr->nbr_stats.delay_trig_refresh;
 
 }
 
 void _nbr_mgr_dump_all_nbr_stats() {
     memset(&gbl_nbr_stats, 0, sizeof(gbl_nbr_stats));
     p_nbr_process_hdl->nbr_db_walk(nbr_mgr_dump_all_nbr_data_stats);
-    NBR_MGR_LOG_ERR("DUMP", "All neighbor STATS refresh:%d delay refresh:%d resolve:%d "
+    NBR_MGR_LOG_ERR("DUMP", "All neighbor STATS refresh:%d delay refresh:%d delay resolve:%d resolve:%d "
                     "retry:%d mac_np:%d fail_trig:%d stale_ref:%d mac_lrn_ref:%d mac_trig_ref:%d "
-                    "FLUSH skip:%d fail_resolve:%d refresh:%d",
-                    gbl_nbr_stats.refresh_cnt, gbl_nbr_stats.delay_refresh_cnt, gbl_nbr_stats.resolve_cnt,
+                    "FLUSH skip:%d fail_resolve:%d refresh:%d delay-state-failed-resolve:%d",
+                    gbl_nbr_stats.refresh_cnt, gbl_nbr_stats.delay_refresh_cnt,
+                    gbl_nbr_stats.delay_resolve_cnt, gbl_nbr_stats.resolve_cnt,
                     gbl_nbr_stats.retry_cnt, gbl_nbr_stats.mac_not_present_cnt,
                     gbl_nbr_stats.failed_trig_resolve_cnt, gbl_nbr_stats.stale_trig_refresh_cnt,
                     gbl_nbr_stats.hw_mac_learn_refresh_cnt, gbl_nbr_stats.mac_trig_refresh,
                     gbl_nbr_stats.flush_skip_refresh, gbl_nbr_stats.flush_failed_resolve,
-                    gbl_nbr_stats.flush_refresh);
+                    gbl_nbr_stats.flush_refresh, gbl_nbr_stats.delay_trig_refresh);
 }
 
 void _nbr_mgr_dump_all_nbr_stats_clear(nbr_data const * ptr) {
@@ -217,7 +224,12 @@ static void _nbr_mgr_dump_nbr_ref(nbr_data_ptr &ptr) {
         if (ptr->get_if_index() != ptr->get_parent_if_index()) {
             p_nbr_process_hdl->nbr_if_list_entry_walk(NBR_MGR_DEFAULT_VRF_ID, ptr->get_parent_if_index(), nbr_mgr_dump_intf_data);
         }
-        p_nbr_process_hdl->mac_if_db_walk(ptr->get_parent_if_index(), nbr_mgr_dump_mac_data);
+        try {
+            std::string mac = ptr->get_mac_ptr()->get_mac_addr().c_str();
+            nbr_mgr_dump_mac_data(p_nbr_process_hdl->mac_db_get(ptr->get_parent_if_index(), mac));
+        } catch(std::invalid_argument& e) {
+            NBR_MGR_LOG_ERR("DUMP", "MAC is not present");
+        }
     }
 }
 

--- a/nbr-mgr/src/nbr_mgr_rslv.cpp
+++ b/nbr-mgr/src/nbr_mgr_rslv.cpp
@@ -117,9 +117,9 @@ static cps_api_object_t nbr_mgr_nbr_to_cps_obj(nbr_mgr_nbr_entry_t *entry,cps_ap
 bool nbr_mgr_burst_resolve_handler(nbr_mgr_msg_t *p_msg) {
     char str[NBR_MGR_MAC_STR_LEN];
     char buff[HAL_INET6_TEXT_LEN + 1];
-    NBR_MGR_LOG_INFO("NETLINK-MSG", "%s the neighbor VRF: %lu(%s) family:%s ip:%s mac:%s"
+    NBR_MGR_LOG_INFO("NETLINK-MSG", "%s(%d) the neighbor VRF: %lu(%s) family:%s ip:%s mac:%s"
                      " if-index:%d (llayer:%d) status:%lu processing",
-                     ((p_msg->type == NBR_MGR_NL_RESOLVE_MSG) ? "Resolve" :"Refresh"),
+                     ((p_msg->type == NBR_MGR_NL_RESOLVE_MSG) ? "Resolve" :"Refresh"), p_msg->type,
                      p_msg->nbr.vrfid, p_msg->nbr.vrf_name,
                      ((p_msg->nbr.family == HAL_INET4_FAMILY) ? "IPv4" : "IPv6"),
                      std_ip_to_string(&(p_msg->nbr.nbr_addr), buff, HAL_INET6_TEXT_LEN),
@@ -139,7 +139,8 @@ bool nbr_mgr_burst_resolve_handler(nbr_mgr_msg_t *p_msg) {
         return false;
     }
     /* Invoke the NAS-linux APIs for Neighbor resolution and refresh */
-    if (p_msg->type == NBR_MGR_NL_RESOLVE_MSG) {
+    if ((p_msg->type == NBR_MGR_NL_RESOLVE_MSG) ||
+        (p_msg->type == NBR_MGR_NL_DELAY_RESOLVE_MSG)) {
         nas_os_resolve_neighbor(obj);
     } else if ((p_msg->type == NBR_MGR_NL_REFRESH_MSG) ||
                (p_msg->type == NBR_MGR_NL_DELAY_REFRESH_MSG)) {
@@ -155,7 +156,8 @@ bool nbr_mgr_nbr_resolve(nbr_mgr_msg_type_t type, nbr_mgr_nbr_entry_t *p_nbr) {
     if (p_msg) {
         p_msg->type = type;
         memcpy(&(p_msg->nbr), p_nbr, sizeof(nbr_mgr_nbr_entry_t));
-        if (type == NBR_MGR_NL_DELAY_REFRESH_MSG) {
+        if ((type == NBR_MGR_NL_DELAY_REFRESH_MSG) ||
+            (type == NBR_MGR_NL_DELAY_RESOLVE_MSG)) {
             nbr_mgr_enqueue_delay_resolve_msg(std::move(p_msg_uptr));
         } else {
             nbr_mgr_enqueue_burst_resolve_msg(std::move(p_msg_uptr));

--- a/src/hal_rt_dr.c
+++ b/src/hal_rt_dr.c
@@ -678,11 +678,17 @@ int fib_proc_dr_add_msg (uint8_t af_index, void *p_rtm_fib_cmd, int *p_nh_info_s
          * RIF for this LLA will be created when the interface mode
          * changes from L2 to L3.
          */
+        bool is_lla_prg_required = false;
         if (FIB_IS_INTF_MODE_L3(p_intf->mode) &&
             (p_intf->admin_status == RT_INTF_ADMIN_STATUS_UP)) {
             if (hal_rif_index_get_or_create(0, dr_msg_info.vrf_id, if_index, &rif_id) == STD_ERR_OK) {
                 hal_rt_rif_ref_inc(dr_msg_info.vrf_id, if_index);
                 p_dr->num_ipv6_rif_link_local++;
+                /* Since the LLA programming is not done yet for this LLA,
+                 * program when the mode is L3 and admin status is up for any LLA */
+                if (p_dr->num_ipv6_rif_link_local == 1) {
+                    is_lla_prg_required = true;
+                }
             } else {
                 HAL_RT_LOG_ERR("HAL-RT-LLA", " RIF get failed for Route add vrf_id: %d, prefix: %s/%d,"
                                " proto: %d out-if:%d link-local-cnt:%d route-present:%d RIF-ref-cnt:%d",
@@ -693,7 +699,7 @@ int fib_proc_dr_add_msg (uint8_t af_index, void *p_rtm_fib_cmd, int *p_nh_info_s
             }
         }
 
-        if (is_route_present) {
+        if (is_route_present && (is_lla_prg_required == false)) {
             p_dr->last_update_time = fib_tick_get ();
             return STD_ERR_OK;
         }
@@ -2896,6 +2902,15 @@ int fib_resolve_dr (t_fib_dr *p_dr)
                    p_nh->vrf_id,
                    FIB_IP_ADDR_TO_STR (&p_nh->key.ip_addr), p_nh->key.if_index);
 
+        /* Dont add the NH into FH list, if the NH is marked for dead */
+        if (p_nh->status_flag & FIB_NH_STATUS_DEAD) {
+            HAL_RT_LOG_DEBUG("HAL-RT-DR",
+                             "NH in dead state. "
+                             "NH: vrf_id: %d, ip_addr: %s, if_index: 0x%x",
+                             p_nh->vrf_id,
+                             FIB_IP_ADDR_TO_STR (&p_nh->key.ip_addr), p_nh->key.if_index);
+            continue;
+        }
         if (FIB_IS_NH_REQ_RESOLVE (p_nh))
         {
             HAL_RT_LOG_DEBUG("HAL-RT-DR",

--- a/src/hal_rt_route.c
+++ b/src/hal_rt_route.c
@@ -316,9 +316,16 @@ dn_hal_route_err _hal_fib_route_add(uint32_t vrf_id, t_fib_dr *p_dr,
             rif_update = false;
             if_index = 0;
         } else if (p_fh == NULL) {
-            p_nh = FIB_GET_FIRST_NH_FROM_DR(p_dr, nh_holder);
-            if (!p_nh) {
-                // @Todo, Need to handle this case
+            bool is_nh_found = false;
+            /* Find the next valid NH, if all NHs are in dead state, return from here */
+            FIB_FOR_EACH_NH_FROM_DR (p_dr, p_nh, nh_holder)
+            {
+                if (!(p_nh->status_flag & FIB_NH_STATUS_DEAD)) {
+                    is_nh_found = true;
+                    break;
+                }
+            }
+            if (is_nh_found == false) {
                 HAL_RT_LOG_DEBUG("HAL-RT-NDI", "Null NH!");
                 return DN_HAL_ROUTE_E_FAIL;
             }

--- a/src/unit_test/hal_rt_dr_unittest.cpp
+++ b/src/unit_test/hal_rt_dr_unittest.cpp
@@ -214,6 +214,18 @@ TEST(hal_rt_dr_test, hal_rt_dr_check_loopback_addr_in_hw) {
     ASSERT_TRUE(rc != cps_api_ret_code_OK);
 }
 
+TEST(hal_rt_dr_test, hal_rt_dr_check_lla) {
+    system("ip -6 addr add fe80::1/128 dev br100");
+    sleep(5);
+    cps_api_return_code_t rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "fe80::1", 128, "default", NULL, NULL, true);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    system("ip link del br100");
+    sleep(5);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "fe80::1", 128, "default", NULL, NULL, true);
+    ASSERT_TRUE(rc != cps_api_ret_code_OK);
+}
+
+
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);
 

--- a/src/unit_test/nas_rt_rif_test.py
+++ b/src/unit_test/nas_rt_rif_test.py
@@ -1,0 +1,298 @@
+#!/usr/bin/python
+# Copyright (c) 2018 Dell Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+# LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+# FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+#
+# See the Apache Version 2.0 License for specific language governing
+# permissions and limitations under the License.
+
+import cps
+from cps_utils import *
+import nas_ut_framework as nas_ut
+import cps_object
+import nas_os_if_utils as nas_if
+import sys
+import binascii
+import subprocess
+import time
+
+#Set following number according to NPU capability
+#num rif for VLANs will be 2 less than max (512), as one is used for base mac and one for default vlan
+num_vlans_to_test=510
+start_vlan_id=2
+mode='OPX'
+member_port='ethernet1/1/9'
+lnx_member_port='e101-009-0'
+
+# attribute id's for VLAN config
+intf_rpc_key_id = 'dell-base-if-cmn/set-interface'
+intf_rpc_op_attr_id = 'dell-base-if-cmn/set-interface/input/operation'
+intf_rpc_op_type_map = {'create': 1, 'delete': 2, 'set': 3}
+
+name_attr_id = 'if/interfaces/interface/name'
+type_attr_id = 'if/interfaces/interface/type'
+admin_attr_id = 'if/interfaces/interface/enabled'
+vlan_attr_id = 'base-if-vlan/if/interfaces/interface/id'
+tagged_port_attr_id = 'dell-if/if/interfaces/interface/tagged-ports'
+vlan_type_attr_id = 'dell-if/if/interfaces/interface/vlan-type'
+vlan_if_type = 'ianaift:l2vlan'
+
+
+def usage():
+    print"\nnas_rt_rif_test.py run-test"
+    print"nas_rt_rif_test.py create vlan-id <id> ip <address> <pref_len>"
+    print"nas_rt_rif_test.py delete vlan-id <id>"
+    print"nas_rt_rif_test.py show [ip <address> <pref_len>]"
+    print"\n"
+
+def nas_vlan_op(op, data_dict):
+    if op == 'get':
+        obj = cps_object.CPSObject( nas_if.get_if_key(), data=data_dict)
+    else:
+        if op in intf_rpc_op_type_map:
+            data_dict[intf_rpc_op_attr_id] = intf_rpc_op_type_map[op]
+        obj = cps_object.CPSObject( intf_rpc_key_id, data=data_dict)
+        op = 'rpc'
+    nas_ut.get_cb_method(op)(obj)
+
+def commit(obj, op):
+    l = []
+    obj_tup = (op, obj.get())
+    l.append(obj_tup)
+    t = CPSTransaction(l)
+    ret = t.commit()
+    return ret
+
+def exec_shell(cmd):
+    proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, shell=True)
+    (out, err) = proc.communicate()
+    return out
+
+def get_sw_mode():
+    global mode
+    mode = 'OPX'
+    ret = exec_shell('os10-show-version | grep \"OS_NAME.*Enterprise\"')
+    if ret:
+        mode = 'DoD'
+
+def handle_get(vrf, af, ip, pref_len):
+    get_list = []
+    npu_prg_done = 0
+    get_obj = CPSObject("base-route/obj/entry")
+    if vrf is not None:
+        get_obj.add_attr("vrf-name", vrf)
+    if (af != 0):
+        get_obj.add_attr("af", af)
+    if ip is not None:
+        addr = binascii.hexlify(socket.inet_pton(socket.AF_INET, ip))
+        get_obj.add_attr("route-prefix", addr)
+    if pref_len is not None:
+        get_obj.add_attr("prefix-len", pref_len)
+    if cps.get([get_obj.get()], get_list):
+        if not get_list:
+            get_list = None
+        else:
+            reply_obj = CPSObject(obj=get_list[0])
+            npu_prg_done = reply_obj.get_attr_data('base-route/obj/entry/npu-prg-done')
+        return get_list,npu_prg_done
+    else:
+        return None, npu_prg_done
+
+def handle_show(vrf, ip, pref_len):
+    get_list, npu_prg_done  = handle_get(vrf, 2, ip, pref_len)
+    if get_list is not None:
+        for i in get_list:
+            print_obj(i)
+        print"\n NPU program done:", npu_prg_done
+    else:
+        print("\n no objects received")
+
+def ip_addr_config(ifname, ip_addr, pref_len):
+    ret = 0
+    if ip_addr is not None:
+        addr = binascii.hexlify(socket.inet_pton(socket.AF_INET, ip_addr))
+        obj = CPSObject('base-ip/ipv4/address',
+                         data= {"base-ip/ipv4/name": ifname, "base-ip/ipv4/address/ip" : addr,
+                           "base-ip/ipv4/address/prefix-length" : pref_len,  })
+        ret = commit(obj, 'create')
+    return ret
+
+def vlan_cps_config(choice, vlan_id, mbr_port, ip_addr = None, pref_len = None):
+    if choice == 'add' and vlan_id != '':
+        vlan_type = 1
+        ifname_list = []
+        ifname_list.insert(0,mbr_port.strip())
+        #create the VLAN
+        nas_vlan_op("create",
+            {vlan_attr_id: vlan_id, type_attr_id:vlan_if_type,
+             tagged_port_attr_id: ifname_list,
+             vlan_type_attr_id: vlan_type, admin_attr_id: 1})
+        #configure IP address
+        if ip_addr is not None:
+            ifname='br'+str(vlan_id)
+            ip_addr_config(ifname,ip_addr,pref_len)
+    elif choice == 'del' and mbr_port != '':
+        ifname='br'+str(vlan_id)
+        nas_vlan_op("delete", {name_attr_id: ifname})
+
+#Verify creation of RIF (my_station_tcam entry) beyond the the h/w limit (512)
+#Expectation is, my_station_tcam entry should be optimized in SAI for VLAN entries.
+#if NPU my_station _tcam entry creation is NOT optimized for VLANs,
+#then this test would fail in verification when creating entries more than 512.
+def run_tests():
+    global num_vlans_to_test
+    ret=0
+    af=2
+    pref_len = 24
+
+    #configuration
+    for i in range (num_vlans_to_test):
+        vlan_id = start_vlan_id+i
+        ip_addr_str="100."+str(vlan_id/250+1)+"."+str(vlan_id%250)+".1"
+        vlan_cps_config('add', vlan_id, lnx_member_port, ip_addr_str,pref_len)
+
+    #verification
+    time.sleep (30)
+    for i in range (num_vlans_to_test):
+        vlan_id = start_vlan_id+i
+        ip_addr_str="100."+str(vlan_id/250+1)+"."+str(vlan_id%250)+".0"
+        get_list, npu_prg_done = handle_get(None, af, ip_addr_str, pref_len)
+        if get_list is None or npu_prg_done is not 1:
+            ret = 1
+            print "validation failed for vlan-"+str(vlan_id)+" IP:"+ip_addr_str
+            break
+    if ret is 1:
+        return ret
+
+    #configure the VLAN entry beyond the max limit
+    vlan_id=start_vlan_id+num_vlans_to_test
+    ip_addr_str="100."+str(vlan_id/250+1)+"."+str(vlan_id%250)+".1"
+    vlan_cps_config('add', vlan_id, lnx_member_port, ip_addr_str,pref_len)
+
+    #verification - for entry beyond max limit
+    time.sleep (10)
+    ip_addr_str="100."+str(vlan_id/250+1)+"."+str(vlan_id%250)+".0"
+    get_list, npu_prg_done = handle_get(None, af, ip_addr_str, pref_len)
+    if get_list is None or npu_prg_done is 1:
+        print "Test Pass: RIF entry/my_station_tcam entry created beyond 512 entries."
+        print get_list
+    else:
+        print "Test Fail: RIF entry/my_station_tcam entry creation failed beyond 512 entries."
+        ret = 1
+
+    return ret
+
+#cleanup
+def run_tests_cleanup():
+    global num_vlans_to_test
+
+    for i in range (num_vlans_to_test):
+        vlan_id = start_vlan_id+i
+        vlan_cps_config('del', vlan_id, lnx_member_port, None, None)
+    #cleanup the last entry created beyond max limit
+    vlan_id=start_vlan_id+num_vlans_to_test
+    vlan_cps_config('del', vlan_id, lnx_member_port, None,None)
+
+def test_pre_req_cfg():
+    global mode
+
+    if mode is 'DoD':
+        #configure via CLI the test pre requisites
+        cfg_file = open('/tmp/test_pre_req', 'w')
+        print>>cfg_file, "configure terminal"
+        print>>cfg_file, "interface range ethernet 1/1/1-1/1/32"
+        print>>cfg_file, "shutdown"
+        print>>cfg_file, "interface "+member_port
+        print>>cfg_file, "no shutdown"
+        print>>cfg_file, "switchport mode trunk"
+        cfg_file.close()
+        exec_shell('sudo -u admin clish --b /tmp/test_pre_req')
+    else:
+        #configure via linux commands the test pre requisites
+        print "UT test for BASE not supported yet"
+
+
+if __name__ == '__main__':
+    vrf = None
+    vlan_id = 0
+    af = 0
+    show = 0
+    delete = 0
+    create = 0
+    ifname = None
+    ip = None
+    pref_len = 0
+    ret = 0
+    if len(sys.argv) == 1:
+        usage()
+    else:
+        get_sw_mode()
+        #for now this UT is supported only for DoD
+        if mode is not 'DoD':
+            sys.exit(1)
+        if (sys.argv[1] in ["show", "create", "delete"]):
+            print("len = ", len(sys.argv))
+            print("command : ", sys.argv[1])
+            arglen = len(sys.argv)
+            if (sys.argv[1] == "show"):
+                show = 1
+            elif (sys.argv[1] == "delete"):
+                delete = 1
+            elif (sys.argv[1] == "create"):
+                create = 1
+            i = 2
+            while (i < arglen):
+                print("\n iteration i", i)
+                if (sys.argv[i] == "vrf"):
+                    i = i + 1
+                    if (i > arglen):
+                        print"\n\n Please reenter vrf-name"
+                    vrf = sys.argv[i]
+                elif (sys.argv[i] == "vlan-id"):
+                    i = i + 1
+                    if (i > arglen):
+                        print"\n\n Please reenter vlan-id"
+                    vlan_id = sys.argv[i]
+                elif (sys.argv[i] == "af"):
+                    i = i + 1
+                    if (i > arglen):
+                        print"\n\n please reenter with af"
+                    af = sys.argv[i]
+                elif (sys.argv[i] == "ifname"):
+                    i = i + 1
+                    if (i > arglen):
+                        print"\n\n please enter ifname"
+                    ifname = sys.argv[i]
+                elif (sys.argv[i] == "ip"):
+                    i = i + 1
+                    if (i > arglen):
+                        print"\n\n please enter ip in hex format ('64010203') prefix_length"
+                    ip = sys.argv[i]
+                    pref_len = sys.argv[i+1]
+                    i = i + 1
+                i = i + 1
+            print(
+                "\n\n cmd with vlan_id, ip, pref_len",
+                vlan_id, ip, pref_len)
+            if (show):
+                handle_show(
+                    vrf,
+                    ip, pref_len)
+            elif (delete):
+                vlan_cps_config('del', vlan_id, member_port)
+            elif (create):
+                vlan_cps_config('add', vlan_id, lnx_member_port, ip, pref_len)
+        elif (sys.argv[1] in ["run-test"]):
+            test_pre_req_cfg()
+            ret = run_tests()
+            run_tests_cleanup()
+        else:
+            usage()
+    sys.exit(ret)

--- a/src/unit_test/run_test
+++ b/src/unit_test/run_test
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 
+./nas_rt_rif_test.py run-test
 ./hal_rt_dr_unittest
 ./nas_rt_offload_cps_unittest
 ./nas_route_cps_unittest


### PR DESCRIPTION
  * Update: Added UT script for PBR ACL cleanup dependency issue
  * Bugfix: 'show ip arp summary' and 'ipv6 neighbor summary' do not clear the
            count on shutting down the ICL ports.
  * Bugfix: arp mismatch is seen between vlt peers after a node reload on a TOR switch.
  * Update: NHT support for non-default VRF.
  * Update: Added support for virtual rif attribute as part of VRRP peer routing MAC configuration.
  * Update: Updated NHT UT scripts to use the logs for validation based on test start time.
  * Bugfix: VLAN LLA missing from "l3 ip6host show" table resulting in failure to learn IPv6 host entries via traffic
  * Bugfix: Missing arp entries on vlt peer
  * Bugfix: show ip arp vrf displaying stale entries after deleting the vrf vlan
  * Update: Handle the RIF creation when the local interface DB is not populated.

Signed-off-by: Rakesh Datta <rakesh.datta6@gmail.com>