### PR TITLE
Increase service start-up timeout

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-l3], [3.9.0+opx3], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-l3], [3.9.0+opx4], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+opx-nas-l3 (3.9.0+opx4) unstable; urgency=medium
+
+  * Update: Increase service start-up time-out
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Thu, 30 Aug 2018  11:36:00 -0800
+
 opx-nas-l3 (3.9.0+opx3) unstable; urgency=medium
 
   * Update: Add support for BGP IPv4 Unnumbering
@@ -44,7 +50,7 @@ opx-nas-l3 (3.6.0) unstable; urgency=medium
   * Update: Program loopback address in NPU
   * Update: Added support for virtual routing IP configuration to configure peer's link local
             address in hardware.
-  * Bugfix: Update the mgmt route status when the default route with eth0 is getting replaced 
+  * Bugfix: Update the mgmt route status when the default route with eth0 is getting replaced
             with default route with null interface.
 
 
@@ -64,12 +70,12 @@ opx-nas-l3 (3.2.0+opx3) unstable; urgency=medium
 
 opx-nas-l3 (3.2.0+opx2) unstable; urgency=medium
 
-  * Update: Modified code to not trigger neighbor refresh on MAC delete/stale notification if the 
+  * Update: Modified code to not trigger neighbor refresh on MAC delete/stale notification if the
             neighbor is already in INCOMPLETE state
   * Update: Synchronized RIF create flows between Native RIF & Peer Routing RIF using nas-l3 lock
   * Update: Modified trace logs to print rif id in hex format
   * Update: Updated cps_route_config.py script to handle static routes configuration for IPv6
-  * Update: Modification to make sure the next dependent route loop is not affected because of the 
+  * Update: Modification to make sure the next dependent route loop is not affected because of the
             current route deletion
   * Update: Event filter implementation to selectively publish the routes to App.
                - Configure event filter for mgmt routes
@@ -80,7 +86,7 @@ opx-nas-l3 (3.2.0+opx2) unstable; urgency=medium
 
 opx-nas-l3 (3.2.0+opx1) unstable; urgency=medium
 
-  * Bugfix: Reset next-hop entry's resolution status upon interface status/mode change. 
+  * Bugfix: Reset next-hop entry's resolution status upon interface status/mode change.
   * Bugfix: Reset the MAC not present flag when the neighbor state moved to FAILED
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 16 Jan 2018 11:00:00 -0800

--- a/scripts/init/opx-nbmgr.service
+++ b/scripts/init/opx-nbmgr.service
@@ -8,7 +8,7 @@ OnFailure=service_onfailure@%n.service
 Type=notify
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/base_nbr_mgr_svc
-TimeoutStartSec=90
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Increase the service start-up timeout to lower the
probability of a service timing out during boot-up.
This change doubles the timeout length.

Signed-off-by: Garrick He <garrick_he@dell.com>