### PR TITLE
Feat: OPX3.1-dev1

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@ libopx_hal_routing_la_SOURCES=src/hal_rt_arp.c src/hal_rt_host.c  src/hal_rt_mpa
                               src/hal_rt_mpath_grp.c src/hal_rt_route.c src/nas_rt_cps.c src/hal_rt_dr.c \
                               src/hal_rt_mem.c src/hal_rt_mpath_util.c src/hal_rt_util.cpp \
                               src/nas_rt_mac.cpp src/hal_rt_intf_util.c src/hal_rt_offload.cpp \
-                              src/nas_rt_virt_routing.cpp
+                              src/nas_rt_virt_routing.cpp src/hal_rt_leak.c
 
 libopx_hal_routing_la_CPPFLAGS= -D_FILE_OFFSET_BITS=64 -I$(top_srcdir)/inc/opx -I$(includedir)/opx $(COMMON_HARDEN_FLAGS) -fPIC
 
@@ -27,7 +27,7 @@ libopx_hal_routing_la_CFLAGS=$(C_HARDEN_FLAGS)
 
 libopx_hal_routing_la_LDFLAGS=-shared -version-info 1:1:0 $(LD_HARDEN_FLAGS)
 
-libopx_hal_routing_la_LIBADD=-lopx_nas_linux -lopx_nas_common -lopx_common -lopx_nas_ndi -lopx_cps_api_common -lopx_logging -lcrypto
+libopx_hal_routing_la_LIBADD=-lopx_nas_linux -lopx_nas_common -lopx_common -lopx_nas_ndi -lopx_cps_api_common -lopx_logging -lcrypto -lpthread
 
 bin_PROGRAMS=base_nbr_mgr_svc
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-l3], [3.9.0+opx3], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-l3], [3.10.1], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,32 @@
+opx-nas-l3 (3.10.1) unstable; urgency=medium
+
+  * Feature: Static L2 VxLAN Support
+  * Bugfix: Increase service timeout
+  * Bugfix: Refresh mgmt neighbors continuously
+  * Bugfix: Flush the IPv4 routes (since OS does not send route del event) that are reachable via IP
+            subnet upon deleting the IP address.
+  * Bugfix: If the interface is down, ARP should not be programmed into hardware and the kernel entry
+            should be changed to failed state
+  * Update: Debug dump routines to include multipath object dump
+  * Update: Modify error log on next hop delete failure to be more informative
+  * Update: NHT get all for all VRFs supported
+  * Update: Add support for virtual rif attribute as part of VRRP peer routing MAC configuration
+  * Update: NHT support for non-default VRF
+  * Update: Add validations to ensure that on destination change (route/nh/nht), the next-hop id that the NHT
+            currently uses will trigger ACL clean-up only if this next-hop id is not
+            being used by any other NHT via connected neighbor.
+  * Update: Process all the routes from change list before deleting the next-hop in the mode change scenario
+  * Update: LLA programming should be done when one of the LLA satisfies the L3 mode and admin up condition
+  * Update: Refresh/Resolve the unresolved neighbors during MAC add processing
+  * Update: Publish the neighbor events during interface mode change when an interface part of non-default
+            VRF is getting deleted
+  * Update: Allow the mgmt interface in the nbr-mgr cache for handling intf events for mgmt neighbors.
+  * Update: Handle the RIF creation when the local interface DB is not populated
+  * Update: Change to accommodate event type change for 1d bridge feature
+  * Update: Renaming nas_ut_framework to nas_common_utils
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Tue, 06 Nov 2018 15:00:00 -0800
+
 opx-nas-l3 (3.9.0+opx3) unstable; urgency=medium
 
   * Update: Add support for BGP IPv4 Unnumbering
@@ -44,7 +73,7 @@ opx-nas-l3 (3.6.0) unstable; urgency=medium
   * Update: Program loopback address in NPU
   * Update: Added support for virtual routing IP configuration to configure peer's link local
             address in hardware.
-  * Bugfix: Update the mgmt route status when the default route with eth0 is getting replaced 
+  * Bugfix: Update the mgmt route status when the default route with eth0 is getting replaced
             with default route with null interface.
 
 
@@ -64,12 +93,12 @@ opx-nas-l3 (3.2.0+opx3) unstable; urgency=medium
 
 opx-nas-l3 (3.2.0+opx2) unstable; urgency=medium
 
-  * Update: Modified code to not trigger neighbor refresh on MAC delete/stale notification if the 
+  * Update: Modified code to not trigger neighbor refresh on MAC delete/stale notification if the
             neighbor is already in INCOMPLETE state
   * Update: Synchronized RIF create flows between Native RIF & Peer Routing RIF using nas-l3 lock
   * Update: Modified trace logs to print rif id in hex format
   * Update: Updated cps_route_config.py script to handle static routes configuration for IPv6
-  * Update: Modification to make sure the next dependent route loop is not affected because of the 
+  * Update: Modification to make sure the next dependent route loop is not affected because of the
             current route deletion
   * Update: Event filter implementation to selectively publish the routes to App.
                - Configure event filter for mgmt routes
@@ -80,7 +109,7 @@ opx-nas-l3 (3.2.0+opx2) unstable; urgency=medium
 
 opx-nas-l3 (3.2.0+opx1) unstable; urgency=medium
 
-  * Bugfix: Reset next-hop entry's resolution status upon interface status/mode change. 
+  * Bugfix: Reset next-hop entry's resolution status upon interface status/mode change.
   * Bugfix: Reset the MAC not present flag when the neighbor state moved to FAILED
 
  -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 16 Jan 2018 11:00:00 -0800

--- a/inc/opx/hal_rt_debug.h
+++ b/inc/opx/hal_rt_debug.h
@@ -113,4 +113,5 @@ void fib_dump_peer_mac_db_get_all_with_vrf(hal_vrf_id_t vrf_id);
 void fib_dump_all_mp_node (uint32_t vrf_id, uint32_t af_index);
 
 void nas_rt_shell_debug_command_init (void);
+
 #endif /* __HAL_RT_DEBUG_H__ */

--- a/inc/opx/hal_rt_mem.h
+++ b/inc/opx/hal_rt_mem.h
@@ -74,6 +74,13 @@
 
 #define FIB_IP_MEM_MALLOC()          (t_fib_ip_addr *)FIB_MALLOC(sizeof (t_fib_ip_addr))
 #define FIB_IP_MEM_FREE(_p_)         FIB_FREE(_p_)
+
+#define FIB_LEAKED_RT_MEM_MALLOC()      (t_fib_leaked_rt*)FIB_MALLOC(sizeof (t_fib_leaked_rt))
+#define FIB_LEAKED_RT_MEM_FREE(_p_)      FIB_FREE(_p_)
+
+#define FIB_VRF_ID_MEM_MALLOC()          (hal_vrf_id_t *)FIB_MALLOC(sizeof (hal_vrf_id_t))
+#define FIB_VRF_ID_MEM_FREE(_p_)         FIB_FREE(_p_)
+
 t_fib_dr *fib_alloc_dr_node (void);
 
 void fib_free_node (t_fib_dr *p_dr);

--- a/inc/opx/hal_rt_util.h
+++ b/inc/opx/hal_rt_util.h
@@ -30,6 +30,7 @@
 #include "std_ip_utils.h"
 #include "dell-base-common.h"
 #include <arpa/inet.h>
+#include "hal_if_mapping.h"
 
 #define FIB_MAX_SCRATCH_BUFSZ             256
 #define FIB_NUM_SCRATCH_BUF               16
@@ -149,13 +150,13 @@ t_std_error hal_rt_get_if_index_from_if_name(char *if_name, hal_vrf_id_t *vrf_id
 bool hal_rt_is_intf_mac_vlan (hal_vrf_id_t vrf_id, hal_ifindex_t if_index);
 bool hal_rt_get_vrf_id(const char *vrf_name, hal_vrf_id_t *vrf_id);
 bool hal_rt_get_vrf_name(hal_vrf_id_t vrf_id, char *vrf_name);
-int fib_process_route_del_on_mgmt_ip_del_event (hal_ifindex_t if_index, hal_vrf_id_t vrf_id,
-                                                t_fib_ip_addr *prefix, uint8_t prefix_len);
+int fib_process_route_del_on_ip_del_event (hal_ifindex_t if_index, hal_vrf_id_t vrf_id,
+                                           t_fib_ip_addr *prefix, uint8_t prefix_len);
 int nas_rt_get_mask (uint8_t af_index, uint8_t prefix_len, t_fib_ip_addr *mask);
 bool hal_rt_is_local_ip_conflict(hal_vrf_id_t vrf_id, hal_ip_addr_t *nbr);
 int fib_route_del_on_intf_down (t_fib_intf *p_intf);
 int fib_process_link_local_address_del_on_intf_event (t_fib_intf *p_intf, t_fib_intf_event_type intf_event);
-int fib_process_nh_del_on_intf_event (t_fib_intf *p_intf, t_fib_intf_event_type intf_event);
+int fib_process_nh_del_on_intf_event (t_fib_intf *p_intf, t_fib_intf_event_type intf_event, bool is_intf_del);
 t_std_error hal_rt_get_parent_if_index_from_l3_intf(hal_vrf_id_t vrf_id, uint32_t if_index,
                                                     uint32_t *p_parent_if_index);
 bool hal_rt_flush_vrf_info(hal_vrf_id_t vrf_id);
@@ -166,5 +167,13 @@ int nas_rt_process_offload_msg(t_fib_offload_msg *p_offload_msg);
 int fib_offload_msg_main(void);
 bool hal_rt_is_vrf_valid(hal_vrf_id_t vrf_id);
 t_std_error fib_process_pending_resolve_dr(int vrf_id, int af_index);
+t_std_error hal_rt_add_dep_leaked_vrf (t_fib_leaked_rt_key *p_parent_route, hal_vrf_id_t leak_vrf_id);
+t_std_error hal_rt_del_dep_leaked_vrf (t_fib_leaked_rt_key *p_parent_route, hal_vrf_id_t leak_vrf_id);
+t_std_error fib_prg_nbr_to_leaked_vrfs_on_parent_nbr_update(t_fib_nh *p_fh, bool is_add);
+t_std_error hal_rt_get_parent_intf_ctrl(hal_vrf_id_t vrf_id, hal_ifindex_t if_index,
+                                        interface_ctrl_t *p_intf_ctrl);
+t_std_error hal_rt_lag_obj_id_get (hal_ifindex_t if_index, ndi_obj_id_t *obj_id);
+t_std_error hal_rt_get_first_vrf_id(hal_vrf_id_t *p_vrf_id);
+t_std_error hal_rt_get_next_vrf_id(hal_vrf_id_t vrf_id, hal_vrf_id_t *p_next_vrf_id);
 #endif /* __HAL_RT_UTIL_H__ */
 

--- a/inc/opx/nas_rt_api.h
+++ b/inc/opx/nas_rt_api.h
@@ -121,11 +121,12 @@ t_std_error nas_route_nht_publish_object(cps_api_object_t obj);
 
 t_std_error nas_route_get_all_arp_info(cps_api_object_list_t list, uint32_t vrf_id, uint32_t af,
                                        hal_ip_addr_t *p_nh_addr, bool is_specific_nh_get,
-                                       bool is_proactive_nh_get);
+                                       bool is_proactive_nh_get, bool is_specific_vrf_get);
 
 cps_api_return_code_t nas_route_process_cps_peer_routing(cps_api_transaction_params_t * param,
                                         size_t ix);
-t_std_error nas_route_get_all_peer_routing_config(cps_api_object_list_t list);
+t_std_error nas_route_get_all_peer_routing_config(bool is_specific_vrf_get, hal_vrf_id_t vrf_id,
+                                                  cps_api_object_list_t list);
 
 cps_api_return_code_t nas_route_process_cps_virtual_routing_ip_cfg (cps_api_transaction_params_t * param,
                                         size_t ix);
@@ -149,9 +150,9 @@ bool nas_route_fdb_add_cps_msg (t_fib_nh *p_nh);
 
 bool nas_route_is_rsvd_intf(hal_ifindex_t nh_if_index);
 cps_api_return_code_t nas_route_process_cps_ip_unreachables_msg(cps_api_transaction_params_t * param, size_t ix);
-cps_api_return_code_t nas_route_get_all_ip_unreach_info(cps_api_object_list_t list, uint32_t af, char *if_name,
-                                              bool is_specific_get);
-cps_api_return_code_t nas_route_os_ip_unreachable_config(uint32_t af, char *if_name, bool is_del, bool is_enable);
+cps_api_return_code_t nas_route_get_all_ip_unreach_info(cps_api_object_list_t list, hal_vrf_id_t vrf_id,
+                                                        uint32_t af, char *if_name, bool is_specific_get);
+cps_api_return_code_t nas_route_os_ip_unreachable_config(char *vrf_name, uint32_t af, char *if_name, bool is_del, bool is_enable);
 cps_api_return_code_t nas_route_process_cps_ip_redirects_msg(cps_api_transaction_params_t * param, size_t ix);
 cps_api_return_code_t nas_route_get_all_ip_redirects_info (cps_api_object_list_t list,
                                                            hal_vrf_id_t vrf_id, char *if_name);

--- a/inc/opx/nbr-mgr/nbr_mgr_cache.h
+++ b/inc/opx/nbr-mgr/nbr_mgr_cache.h
@@ -285,7 +285,7 @@ public:
     }
 
     bool trigger_resolve() const;
-    bool trigger_refresh() const;
+    bool trigger_refresh(bool track_refresh = true) const;
     bool trigger_instant_refresh() const;
     bool trigger_delay_resolve() const;
     bool trigger_delay_refresh() const;
@@ -366,7 +366,7 @@ using nbr_if_list = std::unordered_map<hal_ifindex_t, nbr_mgr_intf_entry_t, nbr_
 class nbr_process {
 
 public:
-    nbr_process() { };
+    nbr_process() { memset(&stats, 0, sizeof(stats));};
 
     //Prevent copy construction and assignment operations
     nbr_process(const nbr_process& src) = delete;

--- a/inc/opx/nbr-mgr/nbr_mgr_msgq.h
+++ b/inc/opx/nbr-mgr/nbr_mgr_msgq.h
@@ -26,6 +26,7 @@
 #include "ds_common_types.h"
 #include "std_type_defs.h"
 #include "cps_api_interface_types.h"
+#include "nas_vrf_utils.h"
 
 #include <deque>
 #include <mutex>
@@ -105,7 +106,7 @@ typedef struct {
                                                or parent interface */
     unsigned long parent_or_child_vrfid; /* VRF-id of the router interface in VRF context (child VRF-id or
                                             parent VRF-id */
-    char vrf_name[HAL_IF_NAME_SZ + 1];
+    char vrf_name[NAS_VRF_NAME_SZ + 1];
     char if_name[HAL_IF_NAME_SZ + 1]; /* interface name */
 } nbr_mgr_intf_entry_t;
 

--- a/nbr-mgr/src/nbr_mgr_cps.cpp
+++ b/nbr-mgr/src/nbr_mgr_cps.cpp
@@ -366,7 +366,7 @@ bool nbr_mgr_refresh_status_db_read() {
         }
         cps_api_object_it_begin(cps_obj,&it);
 
-        char  vrf_name[HAL_IF_NAME_SZ];
+        char  vrf_name[NAS_VRF_NAME_SZ + 1];
         memset (vrf_name,0,sizeof(vrf_name));
         uint32_t af = HAL_INET4_FAMILY, enable = true;
 

--- a/nbr-mgr/src/nbr_mgr_debug.cpp
+++ b/nbr-mgr/src/nbr_mgr_debug.cpp
@@ -21,6 +21,7 @@
 #include "nbr_mgr_main.h"
 #include "nbr_mgr_cache.h"
 #include "nbr_mgr_log.h"
+#include "std_utils.h"
 #include <exception>
 #include <sstream>
 
@@ -361,7 +362,7 @@ void nbr_mgr_dump_nbr(uint32_t af, uint32_t vrf_id, const char *nbr_ip, uint32_t
     memset(&dump, 0, sizeof(dump));
     dump.af = af;
     dump.vrf_id = vrf_id;
-    strncpy(dump.nbr_ip, nbr_ip, sizeof(dump.nbr_ip));
+    safestrncpy(dump.nbr_ip, nbr_ip, sizeof(dump.nbr_ip));
     dump.if_index = if_index;
     dump.type = NBR_MGR_DUMP_NBR;
     nbr_mgr_dump_info(&dump);

--- a/nbr-mgr/src/nbr_mgr_main.cpp
+++ b/nbr-mgr/src/nbr_mgr_main.cpp
@@ -99,7 +99,6 @@ static void sigterm_hdlr(int signo)
 
 /* Nbr Mgr process entry function */
 int main() {
-
     (void)signal(SIGTERM, sigterm_hdlr);
 
     if (!nbr_mgr_init()) {

--- a/nbr-mgr/src/nbr_mgr_nl_evt.cpp
+++ b/nbr-mgr/src/nbr_mgr_nl_evt.cpp
@@ -141,9 +141,9 @@ bool nbr_mgr_cps_obj_to_intf(cps_api_object_t obj, nbr_mgr_intf_entry_t *p_intf)
         NBR_MGR_LOG_INFO("CPS-INTF","Intf:%d is_del:%d flags:0x%x status:%s type:%d",
                          index, is_op_del, p_intf->flags, (is_admin_up ? "Up" : "Down"), type);
         /* Allow only the L2 (bridge) and L3 ports for L3 operations */
-        if ((type != BASE_CMN_INTERFACE_TYPE_L2_PORT) && (type != BASE_CMN_INTERFACE_TYPE_L3_PORT) &&
-            (type != BASE_CMN_INTERFACE_TYPE_LAG) && (type != BASE_CMN_INTERFACE_TYPE_VLAN) &&
-            (type != BASE_CMN_INTERFACE_TYPE_MACVLAN)) {
+        if ((type != BASE_CMN_INTERFACE_TYPE_BRIDGE) && (type != BASE_CMN_INTERFACE_TYPE_L3_PORT) &&
+            (type != BASE_CMN_INTERFACE_TYPE_LAG) && (type != BASE_CMN_INTERFACE_TYPE_L2_PORT) &&
+            (type != BASE_CMN_INTERFACE_TYPE_MACVLAN) && (type != BASE_CMN_INTERFACE_TYPE_MANAGEMENT)) {
             return false;
         }
         /* Incase of LAG/VLAN member delete, ignore it,
@@ -157,15 +157,18 @@ bool nbr_mgr_cps_obj_to_intf(cps_api_object_t obj, nbr_mgr_intf_entry_t *p_intf)
                                      index, p_intf->flags, (is_admin_up ? "Up" : "Down"), type, intf_member_port);
                     return false;
                 }
-            } else if (type == BASE_CMN_INTERFACE_TYPE_VLAN) {
+            } else if (type == BASE_CMN_INTERFACE_TYPE_L2_PORT) {
                 NBR_MGR_LOG_INFO("CPS-INTF","VLAN member del Intf:%d flags:0x%x status:%s type:%d",
                                  index, p_intf->flags, (is_admin_up ? "Up" : "Down"), type);
                 return false;
             }
         }
-        if (type == BASE_CMN_INTERFACE_TYPE_L2_PORT) {
+        if (type == BASE_CMN_INTERFACE_TYPE_BRIDGE) {
             is_bridge = true;
-        } else if (type == BASE_CMN_INTERFACE_TYPE_VLAN) {
+        } else if (type == BASE_CMN_INTERFACE_TYPE_L2_PORT) {
+            /* Make sure only the VLAN flag is set since this event handled
+             * only for VLAN-id update not for admin/oper status update for VLAN interface. */
+            p_intf->flags = 0;
             cps_api_object_attr_t vlan_id_attr =
                 cps_api_object_attr_get(obj, BASE_IF_VLAN_IF_INTERFACES_INTERFACE_ID);
             if (vlan_id_attr) {

--- a/scripts/bin/cps_config_route.py
+++ b/scripts/bin/cps_config_route.py
@@ -17,7 +17,7 @@ import sys
 import getopt
 import cps_utils
 import socket
-import nas_ut_framework as nas_ut
+import nas_common_utils as nas_common
 import nas_route_utils as nas_route
 import netaddr as net
 import time
@@ -80,7 +80,7 @@ def add_embd_param(obj, outer_param, inner_param, val_list, type=''):
 
 def nas_route_op(op, obj, ver):
     nas_route.init(ver)
-    nas_ut.get_cb_method(op)(obj)
+    nas_common.get_cb_method(op)(obj)
 
 
 def usage():

--- a/scripts/init/opx-nbmgr.service
+++ b/scripts/init/opx-nbmgr.service
@@ -8,7 +8,7 @@ OnFailure=service_onfailure@%n.service
 Type=notify
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/base_nbr_mgr_svc
-TimeoutStartSec=90
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target

--- a/src/hal_rt_debug.c
+++ b/src/hal_rt_debug.c
@@ -209,31 +209,31 @@ void fib_dump_vrf_info_per_vrf_per_af (uint32_t vrf_id, uint32_t in_af_index)
     printf ("**************************************************\r\n");
     printf ("  vrf_id                     :  %d\r\n", p_vrf_info->vrf_id);
     printf ("  vrf_name                   :  %s\r\n", p_vrf_info->vrf_name);
-    printf ("  is_vrf_created              :  %d\r\n", p_vrf_info->is_vrf_created);
+    printf ("  is_vrf_created             :  %d\r\n", p_vrf_info->is_vrf_created);
     printf ("  af_index                   :  %d\r\n", p_vrf_info->af_index);
 
-    printf ("  num_dr_processed_by_walker    :  %d\r\n",
+    printf ("  num_dr_processed_by_walker :  %d\r\n",
             p_vrf_info->num_dr_processed_by_walker);
 
-    printf ("  num_nh_processed_by_walker    :  %d\r\n",
+    printf ("  num_nh_processed_by_walker :  %d\r\n",
             p_vrf_info->num_nh_processed_by_walker);
 
-    printf ("  clear_ip_fib_on              :  %d\r\n", p_vrf_info->clear_ip_fib_on);
-    printf ("  clear_ip_route_on            :  %d\r\n", p_vrf_info->clear_ip_route_on);
-    printf ("  clear_arp_on                :  %d\r\n", p_vrf_info->clear_arp_on);
-    printf ("  dr_clear_on                 :  %d\r\n", p_vrf_info->dr_clear_on);
-    printf ("  nh_clear_on                 :  %d\r\n", p_vrf_info->nh_clear_on);
-    printf ("  dr_clear_max_radix_ver        :  %lld\r\n",
+    printf ("  clear_ip_fib_on            :  %d\r\n", p_vrf_info->clear_ip_fib_on);
+    printf ("  clear_ip_route_on          :  %d\r\n", p_vrf_info->clear_ip_route_on);
+    printf ("  clear_arp_on               :  %d\r\n", p_vrf_info->clear_arp_on);
+    printf ("  dr_clear_on                :  %d\r\n", p_vrf_info->dr_clear_on);
+    printf ("  nh_clear_on                :  %d\r\n", p_vrf_info->nh_clear_on);
+    printf ("  dr_clear_max_radix_ver     :  %lld\r\n",
             p_vrf_info->dr_clear_max_radix_ver);
-    printf ("  nh_clear_max_radix_ver        :  %lld\r\n",
+    printf ("  nh_clear_max_radix_ver     :  %lld\r\n",
             p_vrf_info->nh_clear_max_radix_ver);
-    printf ("  dr_ha_on                    :  %d\r\n", p_vrf_info->dr_ha_on);
-    printf ("  nh_ha_on                    :  %d\r\n", p_vrf_info->nh_ha_on);
-    printf ("  is_catch_all_disabled        :  %d\r\n",
+    printf ("  dr_ha_on                   :  %d\r\n", p_vrf_info->dr_ha_on);
+    printf ("  nh_ha_on                   :  %d\r\n", p_vrf_info->nh_ha_on);
+    printf ("  is_catch_all_disabled      :  %d\r\n",
             p_vrf_info->is_catch_all_disabled);
-    printf ("  dr_ha_max_radix_ver           :  %lld\r\n",
+    printf ("  dr_ha_max_radix_ver        :  %lld\r\n",
             p_vrf_info->dr_ha_max_radix_ver);
-    printf ("  nh_ha_max_radix_ver           :  %lld\r\n",
+    printf ("  nh_ha_max_radix_ver        :  %lld\r\n",
             p_vrf_info->nh_ha_max_radix_ver);
 
     printf ("**************************************************\r\n");

--- a/src/hal_rt_leak.c
+++ b/src/hal_rt_leak.c
@@ -1,0 +1,455 @@
+/*
+ * Copyright (c) 2018 Dell Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * THIS CODE IS PROVIDED ON AN *AS IS* BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT
+ * LIMITATION ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS
+ * FOR A PARTICULAR PURPOSE, MERCHANTABLITY OR NON-INFRINGEMENT.
+ *
+ * See the Apache Version 2.0 License for specific language governing
+ * permissions and limitations under the License.
+ */
+
+/*!
+ * \file   hal_rt_leak.c
+ * \brief  This file handles the route leaking related functionality.
+ */
+
+#include "dell-base-routing.h"
+#include "hal_rt_main.h"
+#include "hal_rt_mem.h"
+#include "hal_rt_route.h"
+#include "hal_rt_util.h"
+#include "hal_rt_api.h"
+#include "hal_rt_mem.h"
+#include "nas_rt_api.h"
+
+#include "event_log.h"
+#include "std_ip_utils.h"
+#include "std_utils.h"
+
+#include "cps_api_interface_types.h"
+#include "cps_api_events.h"
+
+
+static std_rt_table   *leaked_rt_tree = NULL;
+
+int fib_create_leaked_rt_tree(void)
+{
+    if (leaked_rt_tree != NULL)
+    {
+        HAL_RT_LOG_DEBUG("HAL-RT-DR-LEAK", "Leaked route tree already created");
+        return STD_ERR_OK;
+    }
+
+    leaked_rt_tree = std_radix_create ("fib_leaked_rt_tree", FIB_RDX_LEAKED_RT_KEY_LEN, NULL, NULL, 0);
+    if (leaked_rt_tree == NULL)
+    {
+        HAL_RT_LOG_ERR("HAL-RT-DR-LEAK", " Leaked route tree creation failed!");
+        return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+    }
+
+    return STD_ERR_OK;
+}
+
+int fib_destroy_leaked_rt_tree(void)
+{
+    if (leaked_rt_tree == NULL)
+    {
+        HAL_RT_LOG_ERR("HAL-RT-DR-LEAK", "Leaked route tree does not exist!");
+        return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+    }
+
+    std_radix_destroy (leaked_rt_tree);
+
+    leaked_rt_tree = NULL;
+
+    return STD_ERR_OK;
+}
+
+t_fib_leaked_rt *fib_get_leaked_rt (uint32_t vrf_id, t_fib_ip_addr *p_prefix, int prefix_len) {
+    t_fib_leaked_rt *p_leaked_rt = NULL;
+    t_fib_leaked_rt_key key;
+
+    memset (&key, 0, sizeof (t_fib_leaked_rt_key));
+    key.vrf_id = vrf_id;
+    memcpy (&key.prefix, p_prefix, sizeof (t_fib_ip_addr));
+    key.prefix_len = prefix_len;
+
+    HAL_RT_LOG_INFO("HAL-RT-LEAK-GET", "Keys - vrf_id: %d, prefix: %s(%d)",
+                    key.vrf_id, FIB_IP_ADDR_TO_STR (&key.prefix), key.prefix_len);
+    p_leaked_rt = (t_fib_leaked_rt*) std_radix_getexact (leaked_rt_tree,
+                                                         (uint8_t *)&key, FIB_RDX_LEAKED_RT_KEY_LEN);
+    if (p_leaked_rt != NULL) {
+        HAL_RT_LOG_INFO("HAL-RT-LEAK-GET", "vrf_id: %d, prefix: %s(%d)",
+                        vrf_id, FIB_IP_ADDR_TO_STR (p_prefix), prefix_len);
+    }
+
+    return p_leaked_rt;
+}
+
+
+t_std_error hal_rt_add_dep_leaked_vrf (t_fib_leaked_rt_key *p_parent_route, hal_vrf_id_t vrf_id)
+{
+    t_fib_link_node  *p_link_node = NULL;
+
+    t_fib_leaked_rt *p_leaked_rt = fib_get_leaked_rt(p_parent_route->vrf_id, &p_parent_route->prefix,
+                                                     p_parent_route->prefix_len);
+    if (p_leaked_rt == NULL) {
+        p_leaked_rt = (t_fib_leaked_rt*) FIB_LEAKED_RT_MEM_MALLOC();
+        if (p_leaked_rt == NULL) {
+            HAL_RT_LOG_ERR("DR-LEAK-VRF-ADD","Leaked rt memory allocation failed!");
+            return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+        }
+
+        HAL_RT_LOG_INFO("DR-LEAK-VRF-ADD", "Add - parent route node - vrf_id: %d, prefix: %s/%d, "
+                         "leaked VRF-id:%d", p_parent_route->vrf_id,
+                         FIB_IP_ADDR_TO_STR (&p_parent_route->prefix), p_parent_route->prefix_len,
+                         vrf_id);
+        memset(p_leaked_rt, 0, sizeof(t_fib_leaked_rt));
+        std_dll_init (&p_leaked_rt->leaked_vrf_list);
+        p_leaked_rt->key.vrf_id = p_parent_route->vrf_id;
+        memcpy (&p_leaked_rt->key.prefix, &p_parent_route->prefix, sizeof (t_fib_ip_addr));
+        p_leaked_rt->key.prefix_len = p_parent_route->prefix_len;
+
+        p_leaked_rt->rt_head.rth_addr = (uint8_t *) (&(p_leaked_rt->key));
+        std_rt_head *p_radix_head = std_radix_insert (leaked_rt_tree, (std_rt_head *)(&p_leaked_rt->rt_head),
+                                                      FIB_RDX_LEAKED_RT_KEY_LEN);
+        if (p_radix_head == NULL)
+        {
+            HAL_RT_LOG_ERR("DR-LEAK-VRF-ADD","Radix insertion failed. ");
+            FIB_LEAKED_RT_MEM_FREE(p_leaked_rt);
+            return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+        }
+
+        if (p_radix_head != ((std_rt_head *)p_leaked_rt))
+        {
+            HAL_RT_LOG_ERR("DR-LEAK-VRF-ADD","Duplicate Radix insertion for leaked route!");
+            FIB_LEAKED_RT_MEM_FREE(p_leaked_rt);
+            p_leaked_rt = (t_fib_leaked_rt *) p_radix_head;
+        }
+    }
+
+    p_link_node = (t_fib_link_node *) FIB_LINK_NODE_MEM_MALLOC ();
+    if (p_link_node == NULL)
+    {
+        HAL_RT_LOG_ERR("DR-LEAK-VRF-ADD","Memory alloc failed for leak VRF node!");
+        return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+    }
+    hal_vrf_id_t *p_vrf_id = (hal_vrf_id_t *) FIB_VRF_ID_MEM_MALLOC();
+    if (p_vrf_id == NULL)
+    {
+        FIB_LINK_NODE_MEM_FREE(p_link_node);
+        HAL_RT_LOG_ERR("DR-LEAK-VRF-ADD","Memory alloc failed for VRF!");
+        return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+    }
+
+    memset (p_link_node, 0, sizeof (t_fib_link_node));
+    *p_vrf_id = vrf_id;
+
+    p_link_node->self = p_vrf_id;
+
+    std_dll_insertatback (&p_leaked_rt->leaked_vrf_list, &p_link_node->glue);
+
+    HAL_RT_LOG_INFO("DR-LEAK-VRF-ADD", "Add - parent route node - vrf_id: %d, prefix: %s/%d, "
+                    "leaked VRF-id:%d successful", p_parent_route->vrf_id,
+                    FIB_IP_ADDR_TO_STR (&p_parent_route->prefix), p_parent_route->prefix_len,
+                    vrf_id);
+    t_fib_leaked_rt *p_get_leaked_rt = fib_get_leaked_rt(p_parent_route->vrf_id, &p_parent_route->prefix,
+                                                     p_parent_route->prefix_len);
+    if (p_get_leaked_rt == NULL) {
+        HAL_RT_LOG_ERR("DR-LEAK-VRF-ADD", "Add - parent route node - vrf_id: %d, prefix: %s/%d, "
+                       "leaked VRF-id:%d failed!", p_parent_route->vrf_id,
+                       FIB_IP_ADDR_TO_STR (&p_parent_route->prefix), p_parent_route->prefix_len,
+                       vrf_id);
+        FIB_LINK_NODE_MEM_FREE(p_link_node);
+        return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+    }
+    t_fib_vrf_holder vrf_holder;
+    FIB_FOR_EACH_LEAKED_VRF_FROM_DR(p_get_leaked_rt, p_vrf_id, vrf_holder)
+    {
+        HAL_RT_LOG_INFO("DR-LEAK-VRF-ADD", "Current leaked VRF:%d", *p_vrf_id);
+    }
+    return STD_ERR_OK;
+}
+
+int hal_rt_del_dep_leaked_vrf(t_fib_leaked_rt_key *p_parent_route, hal_vrf_id_t vrf_id)
+{
+    t_fib_link_node  *p_link_node = NULL;
+    hal_vrf_id_t     *p_vrf_id = NULL;
+    t_fib_vrf_holder vrf_holder;
+
+    t_fib_leaked_rt *p_leaked_rt = fib_get_leaked_rt(p_parent_route->vrf_id,
+                                                     &p_parent_route->prefix, p_parent_route->prefix_len);
+    if (p_leaked_rt == NULL) {
+        HAL_RT_LOG_ERR("DR-LEAK-VRF-DEL", "parent route node - vrf_id: %d, prefix: %s/%d, "
+                       "leaked VRF-id:%d does not exist!", p_parent_route->vrf_id,
+                       FIB_IP_ADDR_TO_STR (&p_parent_route->prefix), p_parent_route->prefix_len,
+                       vrf_id);
+        return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+    }
+    FIB_FOR_EACH_LEAKED_VRF_FROM_DR(p_leaked_rt, p_vrf_id, vrf_holder)
+    {
+        if ((*p_vrf_id >= FIB_MAX_VRF) || (hal_rt_access_fib_vrf(*p_vrf_id) == NULL)) {
+            HAL_RT_LOG_ERR("DR-LEAK-VRF-DEL", "Invalid VRF-id:%d", *p_vrf_id);
+            continue;
+        }
+
+        if (*p_vrf_id == vrf_id) {
+            p_link_node = FIB_GET_LINK_NODE_FROM_VRF_HOLDER(vrf_holder);
+            if (p_link_node) {
+                std_dll_remove (&p_leaked_rt->leaked_vrf_list, &p_link_node->glue);
+
+                FIB_VRF_ID_MEM_FREE(p_link_node->self);
+                memset (p_link_node, 0, sizeof (t_fib_link_node));
+                FIB_LINK_NODE_MEM_FREE (p_link_node);
+                HAL_RT_LOG_INFO("DR-LEAK-VRF-DEL", "Parent route node - vrf_id: %d, prefix: %s/%d, "
+                                "leaked VRF-id:%d deletion successful", p_parent_route->vrf_id,
+                                FIB_IP_ADDR_TO_STR (&p_parent_route->prefix), p_parent_route->prefix_len,
+                                vrf_id);
+            }
+
+            break;
+        }
+    }
+
+    if (FIB_GET_FIRST_LEAKED_VRF_FROM_DR(p_leaked_rt, vrf_holder) == NULL) {
+        std_radix_remove (leaked_rt_tree, (std_rt_head *)(&p_leaked_rt->rt_head));
+        memset (p_leaked_rt, 0, sizeof (t_fib_leaked_rt));
+        FIB_LEAKED_RT_MEM_FREE(p_leaked_rt);
+        HAL_RT_LOG_INFO("DR-LEAK-VRF-DEL", "Parent route node - vrf_id: %d, prefix: %s/%d deleted!",
+                        p_parent_route->vrf_id, FIB_IP_ADDR_TO_STR (&p_parent_route->prefix),
+                        p_parent_route->prefix_len);
+    }
+    return STD_ERR_OK;
+}
+
+/* This function programs the parent ARPs/Neighbors into the leaked VRF
+ * when the ARPs/Neighbors programming is successful in the parent VRF. */
+t_std_error fib_prg_nbr_to_leaked_vrfs_on_parent_nbr_update(t_fib_nh *p_fh, bool is_add)
+{
+    hal_vrf_id_t     *p_vrf_id = NULL;
+    t_fib_vrf_holder vrf_holder;
+    t_fib_nh_holder     nh_holder;
+
+    if (!p_fh) {
+        return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+    }
+
+    t_fib_vrf_info *p_vrf_info = hal_rt_access_fib_vrf_info(p_fh->vrf_id, p_fh->key.ip_addr.af_index);
+    if (p_vrf_info == NULL) {
+        return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+    }
+
+    HAL_RT_LOG_INFO("HAL-RT-DR-LEAK", "is_add:%d FH: vrf_id: %d(%s), host: %s",
+                   is_add, p_fh->vrf_id, p_vrf_info->vrf_name,
+                   FIB_IP_ADDR_TO_STR (&p_fh->key.ip_addr));
+    t_fib_dr *p_dr = fib_get_best_fit_dr(p_fh->vrf_id, &p_fh->key.ip_addr);
+    while(p_dr) {
+        HAL_RT_LOG_INFO("HAL-RT-DR-LEAK", "is_add:%d DR: vrf_id: %d(%s), prefix: %s/%d ",
+                        is_add, p_dr->vrf_id, p_vrf_info->vrf_name,
+                        FIB_IP_ADDR_TO_STR (&p_dr->key.prefix), p_dr->prefix_len);
+        t_fib_nh *p_nh = FIB_GET_FIRST_NH_FROM_DR(p_dr, nh_holder);
+        if ((p_dr->num_nh != 1) || (p_dr->rt_type == RT_CACHE) ||
+            (p_nh == NULL) || (p_nh->key.if_index != p_fh->key.if_index) || !(FIB_IS_NH_ZERO(p_nh))) {
+            break;
+        }
+        if (p_nh) {
+            HAL_RT_LOG_INFO("HAL-RT-DR-LEAK", "is_add:%d DR: vrf_id: %d(%s), prefix: %s/%d NH:%s nh-cnt:%d if-index nh:%d fh:%d",
+                            is_add, p_dr->vrf_id, p_vrf_info->vrf_name,
+                            FIB_IP_ADDR_TO_STR (&p_dr->key.prefix), p_dr->prefix_len, FIB_IP_ADDR_TO_STR(&p_nh->key.ip_addr),
+                            p_dr->num_nh,
+                            p_nh->key.if_index, p_fh->key.if_index);
+        }
+        t_fib_leaked_rt *p_leaked_rt = fib_get_leaked_rt(p_dr->vrf_id, &p_dr->key.prefix, p_dr->prefix_len);
+        if (p_leaked_rt) {
+            FIB_FOR_EACH_LEAKED_VRF_FROM_DR(p_leaked_rt, p_vrf_id, vrf_holder)
+            {
+                if ((*p_vrf_id >= FIB_MAX_VRF) || (hal_rt_access_fib_vrf(*p_vrf_id) == NULL)) {
+                    HAL_RT_LOG_ERR("HAL-RT-DR-LEAK", "Invalid VRF-id:%d", *p_vrf_id);
+                    continue;
+                }
+                p_vrf_info = hal_rt_access_fib_vrf_info(*p_vrf_id, p_fh->key.ip_addr.af_index);
+                if (p_vrf_info == NULL) {
+                    HAL_RT_LOG_ERR("HAL-RT-DR-LEAK", "is_add:%d leaked-VRF:%d is not found!",
+                                   is_add, *p_vrf_id);
+                    continue;
+                }
+                HAL_RT_LOG_INFO("HAL-RT-DR-LEAK", "is_add:%d host:%s leaked-VRF:%d(%s)!",
+                                is_add, FIB_IP_ADDR_TO_STR (&p_fh->key.ip_addr), *p_vrf_id, p_vrf_info->vrf_name);
+                hal_rt_leaked_nbr_prg(*p_vrf_id, p_fh, is_add);
+            }
+        }
+        break;
+    }
+
+    return STD_ERR_OK;
+}
+
+/* Program the neighbors from parent VRF context to leaked VRF context */
+t_std_error fib_prg_parent_nbrs_on_leaked_vrf(hal_ifindex_t if_index, const t_fib_dr *p_parent_dr,
+                                              hal_vrf_id_t leaked_vrf_id, bool is_add) {
+    t_fib_nh        *p_fh = NULL;
+    t_fib_nh_holder nh_holder;
+    t_fib_intf *p_intf = NULL;
+    t_fib_ip_addr mask;
+
+    HAL_RT_LOG_INFO("DR-LEAK-NBR-PRG", "is_add:%d intf:%d vrf_id: %d, prefix: %s, prefix_len: %d leaked-VRF:%d",
+                    is_add, if_index, p_parent_dr->vrf_id, FIB_IP_ADDR_TO_STR (&p_parent_dr->key.prefix),
+                    p_parent_dr->prefix_len, leaked_vrf_id);
+    p_intf = fib_get_intf (if_index, p_parent_dr->vrf_id, p_parent_dr->key.prefix.af_index);
+    if (p_intf == NULL) {
+        HAL_RT_LOG_ERR("DR-LEAK-NBR-PRG", "intf:%d not present for vrf_id: %d, prefix: %s, prefix_len: %d leaked-VRF:%d",
+                       if_index, p_parent_dr->vrf_id, FIB_IP_ADDR_TO_STR (&p_parent_dr->key.prefix),
+                       p_parent_dr->prefix_len, leaked_vrf_id);
+        return STD_ERR_OK;
+    }
+    memset (&mask, 0, sizeof (t_fib_ip_addr));
+    if (nas_rt_get_mask (p_parent_dr->key.prefix.af_index, p_parent_dr->prefix_len, &mask) == false) {
+        HAL_RT_LOG_ERR("DR-LEAK-NBR-PRG", "intf:%d vrf_id: %d, prefix: %s, prefix_len: %d leaked-VRF:%d get mask failed",
+                       if_index, p_parent_dr->vrf_id, FIB_IP_ADDR_TO_STR (&p_parent_dr->key.prefix),
+                       p_parent_dr->prefix_len, leaked_vrf_id);
+        return STD_ERR_OK;
+    }
+
+    /* Loop for all the FH and program into the leaked VRF */
+    FIB_FOR_EACH_FH_FROM_INTF (p_intf, p_fh, nh_holder) {
+        if (FIB_IS_NH_ZERO(p_fh)) {
+            HAL_RT_LOG_INFO("DR-LEAK-NBR-PRG", "intf:%d vrf_id: %d, prefix: %s, prefix_len: %d leaked-VRF:%d NH zero",
+                           if_index, p_parent_dr->vrf_id, FIB_IP_ADDR_TO_STR (&p_parent_dr->key.prefix),
+                           p_parent_dr->prefix_len, leaked_vrf_id);
+            continue;
+        }
+        if (FIB_IS_IP_ADDR_IN_PREFIX(&p_fh->key.ip_addr, &mask, &p_parent_dr->key.prefix)) {
+            HAL_RT_LOG_INFO("DR-LEAK-NBR-PRG", "is_add:%d host:%s leaked-VRF:%d",
+                           is_add, FIB_IP_ADDR_TO_STR (&p_fh->key.ip_addr), leaked_vrf_id);
+            hal_rt_leaked_nbr_prg(leaked_vrf_id, p_fh, is_add);
+        }
+    }
+    return STD_ERR_OK;
+}
+
+/* On connected route update, handle the ARPs/Neighbors for leaked VRF. */
+t_std_error fib_prg_leaked_nbrs_on_leaked_route_update(hal_ifindex_t if_index, t_fib_dr *p_parent_dr,
+                                                       hal_vrf_id_t leaked_vrf_id, bool is_add) {
+    return (fib_prg_parent_nbrs_on_leaked_vrf(if_index, p_parent_dr, leaked_vrf_id, is_add));
+}
+
+
+t_std_error fib_prg_leaked_nbrs_on_parent_route_update(t_fib_dr *p_dr, bool is_add) {
+    t_fib_nh_holder nh_holder;
+    t_fib_vrf_holder vrf_holder;
+    hal_vrf_id_t     *p_vrf_id = NULL;
+
+    t_fib_leaked_rt *p_leaked_rt = fib_get_leaked_rt(p_dr->vrf_id, &p_dr->key.prefix, p_dr->prefix_len);
+    if (p_leaked_rt == NULL) {
+        return STD_ERR_OK;
+    }
+    t_fib_nh *p_nh = FIB_GET_FIRST_NH_FROM_DR(p_dr, nh_holder);
+    if ((p_dr->num_nh != 1) || (p_dr->rt_type == RT_CACHE) ||
+        (p_nh == NULL) || !(FIB_IS_NH_ZERO(p_nh))) {
+        return STD_ERR_OK;
+    }
+    FIB_FOR_EACH_LEAKED_VRF_FROM_DR(p_leaked_rt, p_vrf_id, vrf_holder)
+    {
+        HAL_RT_LOG_INFO("LEAK-DR-UPD", "VRF-id:%d prefix:%s(%d) leaked:%d", p_dr->vrf_id,
+                       FIB_IP_ADDR_TO_STR(&p_dr->key.prefix), p_dr->prefix_len, *p_vrf_id);
+        if ((*p_vrf_id >= FIB_MAX_VRF) || (hal_rt_access_fib_vrf(*p_vrf_id) == NULL)) {
+            HAL_RT_LOG_ERR("HAL-RT-DR-LEAK", "Invalid VRF-id:%d", *p_vrf_id);
+            continue;
+        }
+        fib_prg_parent_nbrs_on_leaked_vrf(p_nh->key.if_index, p_dr, *p_vrf_id, is_add);
+    }
+
+    return STD_ERR_OK;
+}
+
+
+t_std_error hal_rt_leaked_nbr_prg(hal_vrf_id_t vrf_id, t_fib_nh *p_fh, bool is_add) {
+    t_fib_nh *p_nh = NULL;
+
+    if (is_add) {
+        p_nh = fib_proc_nh_add (vrf_id, &p_fh->key.ip_addr,
+                                p_fh->key.if_index, FIB_NH_OWNER_TYPE_ARP, 0, false, p_fh->vrf_id);
+        if (p_nh == NULL) {
+            HAL_RT_LOG_ERR("LEAK-NBR-PRG", "NH addition failed. "
+                           "Leaked VRF:%d parent VRF:%d, ip_addr:%s, if_index: %d",
+                           vrf_id, p_fh->vrf_id, FIB_IP_ADDR_TO_STR (&p_fh->key.ip_addr),
+                           p_fh->key.if_index);
+            return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+        }
+
+        if (p_nh->p_arp_info == NULL) {
+            HAL_RT_LOG_ERR("LEAK-NBR-PRG", "NH's ARP info is NULL"
+                           "Leaked VRF:%d parent VRF:%d, ip_addr:%s, if_index: %d",
+                           vrf_id, p_fh->vrf_id, FIB_IP_ADDR_TO_STR (&p_fh->key.ip_addr),
+                           p_fh->key.if_index);
+            return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+        }
+
+        p_nh->p_arp_info->if_index = p_fh->p_arp_info->if_index;
+        p_nh->p_arp_info->mbr_if_index = p_fh->p_arp_info->mbr_if_index;
+        memcpy((uint8_t *)&p_nh->p_arp_info->mac_addr, (uint8_t *)&p_fh->p_arp_info->mac_addr, HAL_RT_MAC_ADDR_LEN);
+        p_nh->p_arp_info->arp_status = p_fh->p_arp_info->arp_status;
+        if (p_nh->p_arp_info->arp_status == RT_NUD_REACHABLE)
+            p_nh->reachable_state_time_stamp = nas_rt_get_clock_sec();
+
+        p_nh->p_arp_info->state = p_fh->p_arp_info->state;
+        p_nh->p_arp_info->is_l2_fh = p_fh->p_arp_info->is_l2_fh;
+    } else {
+        p_nh = fib_get_nh (vrf_id, &p_fh->key.ip_addr, p_fh->key.if_index);
+        if ((p_nh == NULL) ||
+            (p_nh->p_arp_info == NULL)) {
+            HAL_RT_LOG_INFO("LEAK-NBR-PRG", "NH or NH's ARP info is NULL"
+                           "Leaked VRF:%d parent VRF:%d, ip_addr:%s, if_index: %d",
+                           vrf_id, p_fh->vrf_id, FIB_IP_ADDR_TO_STR (&p_fh->key.ip_addr),
+                           p_fh->key.if_index);
+            return (STD_ERR_MK(e_std_err_ROUTE, e_std_err_code_FAIL, 0));
+        }
+
+        fib_proc_nh_delete (p_nh, FIB_NH_OWNER_TYPE_ARP, 0);
+    }
+
+    fib_resume_nh_walker_thread(p_fh->key.ip_addr.af_index);
+    return STD_ERR_OK;
+}
+
+t_std_error fib_process_neigh_flush(t_fib_neigh_flush *flush)
+{
+    hal_vrf_id_t parent_vrf_id = 0, nh_vrf_id = 0;
+    t_fib_ip_addr nh_addr;
+    hal_ifindex_t if_index = 0;
+    t_fib_nh *parent_nh = NULL;
+
+    if (!(FIB_IS_VRF_ID_VALID (flush->vrf_id))) {
+        HAL_RT_LOG_ERR("NEIGH-FLUSH", "VRF-id:%d  is not valid!", flush->vrf_id);
+        return STD_ERR_OK;
+    }
+
+    t_fib_nh *p_nh = fib_get_first_nh(flush->vrf_id, flush->af_index);
+    while (p_nh) {
+        nh_vrf_id = p_nh->vrf_id;
+        parent_vrf_id = p_nh->parent_vrf_id;
+        if_index = p_nh->key.if_index;
+        memcpy(&nh_addr, &p_nh->key.ip_addr, sizeof(nh_addr));
+        if ((nh_vrf_id != parent_vrf_id) &&
+            ((flush->if_index == 0) || (if_index == flush->if_index))) {
+
+            fib_nh_del_nh(p_nh, false);
+
+            /* Check if there is a parent NH, if exists, re-program the neighbor, if not delete the cache */
+            parent_nh = fib_get_nh (parent_vrf_id, &nh_addr, if_index);
+            if (parent_nh) {
+                hal_rt_leaked_nbr_prg(flush->vrf_id, parent_nh, true);
+            }
+        }
+        p_nh = fib_get_next_nh (nh_vrf_id, &nh_addr, if_index);
+    }
+    fib_resume_nh_walker_thread(flush->af_index);
+    return STD_ERR_OK;
+}
+

--- a/src/hal_rt_mpath.c
+++ b/src/hal_rt_mpath.c
@@ -249,7 +249,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
                         HAL_RT_LOG_DEBUG("HAL-RT-NDI",
                                          "NH Group: FH nh_handle is NULL. Creating!" "if_index %d Vrf_id: %d.",
                                          p_fh->key.if_index, vrf_id);
-                        if (hal_rif_index_get_or_create(npu_id, vrf_id, p_fh->key.if_index,
+                        if (hal_rif_index_get_or_create(npu_id, p_fh->vrf_id, p_fh->key.if_index,
                                                         &rif_id) != STD_ERR_OK) {
                             HAL_RT_LOG_ERR("HAL-RT-NDI", "RIF creation failed for host:%s "
                                            "while programming the route:%s/%d",
@@ -489,6 +489,7 @@ dn_hal_route_err hal_fib_ecmp_route_add(uint32_t vrf_id, t_fib_dr *p_dr)
                             p_dr->prefix_len, p_dr->nh_handle, nh_group_handle,
                             (ecmp_handle_created && p_dr->ofh_cnt <= 1) ?
                             "(Changed non-ECMP to ECMP)" : "");
+
             /*
              * If ECMP group table us full, route will be set as non-ECMP.
              * So cleanup the reference to old multipath object, so that when

--- a/src/hal_rt_mpath_grp.c
+++ b/src/hal_rt_mpath_grp.c
@@ -153,7 +153,6 @@ t_std_error hal_rt_find_or_create_ecmp_group(t_fib_dr *p_dr, ndi_nh_group_t *ent
 
     npu_id_t            unit;
     int                 is_mp_obj_created;
-    int                 is_mp_obj_replaced;
     int                 error_occured = false;
     int                 ecmp_count;
     t_fib_hal_dr_info   *p_hal_dr_info;
@@ -167,7 +166,6 @@ t_std_error hal_rt_find_or_create_ecmp_group(t_fib_dr *p_dr, ndi_nh_group_t *ent
 
     *p_out_is_mp_table_full   = false;
     is_mp_obj_created  = false;
-    is_mp_obj_replaced = false;
     if (p_dr->nh_count > ((hal_rt_access_fib_config())->ecmp_max_paths)) {
         ecmp_count         = (hal_rt_access_fib_config())->ecmp_max_paths;
     }else {
@@ -243,10 +241,6 @@ t_std_error hal_rt_find_or_create_ecmp_group(t_fib_dr *p_dr, ndi_nh_group_t *ent
                      */
                     error_occured = true;
                 }
-                else
-                {
-                    is_mp_obj_replaced = true;
-                }
             }
             else
             {
@@ -302,9 +296,6 @@ t_std_error hal_rt_find_or_create_ecmp_group(t_fib_dr *p_dr, ndi_nh_group_t *ent
             if (is_mp_obj_created == true)
             {
                 hal_rt_fib_check_and_delete_mp_obj (p_dr, p_mp_obj, entry->npu_id, true, false);
-            }
-            if (is_mp_obj_replaced == true) {
-                hal_rt_fib_check_and_delete_mp_obj (p_dr, p_mp_obj, entry->npu_id, false, false);
             }
 
             if (*p_out_is_mp_table_full == true) {

--- a/src/hal_rt_mpath_util.c
+++ b/src/hal_rt_mpath_util.c
@@ -424,10 +424,10 @@ t_std_error hal_rt_fib_check_and_delete_old_groupid(t_fib_dr *p_dr, npu_id_t  un
         if (rc != STD_ERR_OK) {
             HAL_RT_LOG_ERR ("HAL-RT-NDI",
                             "NH Group: Old Group ID delete failed. gid %lu VRF %d. Prefix: "
-                              "%s/%d, Unit: %d, Err: %d",
-                              p_dr->onh_handle,  p_dr->vrf_id,
-                              FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
-                              p_dr->prefix_len, unit, rc);
+                            "%s/%d, Unit: %d, Err: %d",
+                            p_dr->onh_handle,  p_dr->vrf_id,
+                            FIB_IP_ADDR_TO_STR (&p_dr->key.prefix),
+                            p_dr->prefix_len, unit, rc);
             return (STD_ERR(ROUTE, FAIL, 0));
         } else {
             HAL_RT_LOG_DEBUG ("HAL-RT-NDI",
@@ -555,5 +555,4 @@ int fib_destroy_mp_md5_tree (t_fib_vrf_info *p_vrf_info)
 
     return STD_ERR_OK;
 }
-
 

--- a/src/nas_rt_virt_routing.cpp
+++ b/src/nas_rt_virt_routing.cpp
@@ -180,7 +180,7 @@ t_std_error nas_route_get_all_virtual_routing_ip_config (cps_api_object_list_t l
 
             std_mutex_simple_lock_guard l(&nas_rt_ip_mutex);
             auto vrf_it = virtual_routing_ip_list.find(vrf_id);
-            if(vrf_it == virtual_routing_ip_list.end()) return STD_ERR_OK;
+            if(vrf_it == virtual_routing_ip_list.end()) { continue; }
             auto &ip_list = vrf_it->second;
 
             for(auto& ip_it: ip_list){
@@ -217,7 +217,7 @@ t_std_error nas_route_get_all_virtual_routing_ip_config (cps_api_object_list_t l
         if(ip_it == ip_list.end()) return STD_ERR_OK;
 
         auto& if_ip_list = ip_it->second;
-        std::string if_name_str = p_cfg->if_name;
+        std::string if_name_str(p_cfg->if_name);
         auto if_name_it = if_ip_list.find(if_name_str);
         if(if_name_it == if_ip_list.end()) return STD_ERR_OK;
 

--- a/src/unit_test/nas_route_cps_unittest.cpp
+++ b/src/unit_test/nas_route_cps_unittest.cpp
@@ -377,31 +377,36 @@ TEST(std_nas_route_test, nas_mgmt_route_del_mgmt_vrf) {
     nas_ut_route_test(0, 0, AF_INET, "65.0.0.0", 16, "10.11.70.254", 0, NULL, "management");
     nas_ut_route_test(0, 0, AF_INET6, "6::", 64, NULL, 0, "eth0", "management");
 }
-
+*/
 
 TEST(std_nas_route_test, nas_default_v6_route_add_blackhole) {
-    nas_ut_route_op_spl_nh (1, "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_BLACKHOLE, AF_INET6);
+    nas_ut_route_op_spl_nh (1, "default", "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_BLACKHOLE, AF_INET6);
 }
 
 TEST(std_nas_route_test, nas_default_v6_route_add_unreachable) {
-    nas_ut_route_op_spl_nh (1, "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_UNREACHABLE, AF_INET6);
+    nas_ut_route_op_spl_nh (1, "default", "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_UNREACHABLE, AF_INET6);
 }
 
 TEST(std_nas_route_test, nas_default_v6_route_add_prohibit) {
-    nas_ut_route_op_spl_nh (1, "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_PROHIBIT, AF_INET6);
+    nas_ut_route_op_spl_nh (1, "default", "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_PROHIBIT, AF_INET6);
 }
 
+/*
 TEST(std_nas_route_test, nas_default_v6_route_del_blackhole) {
-    nas_ut_route_op_spl_nh (0, "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_BLACKHOLE, AF_INET6);
+    nas_ut_route_op_spl_nh (0, "default", "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_BLACKHOLE, AF_INET6);
 }
 
 TEST(std_nas_route_test, nas_default_v6_route_del_unreachable) {
-    nas_ut_route_op_spl_nh (0, "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_UNREACHABLE, AF_INET6);
+    nas_ut_route_op_spl_nh (0, "default", "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_UNREACHABLE, AF_INET6);
 }
 
 TEST(std_nas_route_test, nas_default_v6_route_del_prohibit) {
-    nas_ut_route_op_spl_nh (0, "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_PROHIBIT, AF_INET6);
+    nas_ut_route_op_spl_nh (0, "default", "0::0", 0, BASE_ROUTE_SPECIAL_NEXT_HOP_PROHIBIT, AF_INET6);
 }
+
+*/
+
+
 TEST(std_nas_route_test, nas_route_add) {
 
     cps_api_object_t obj = cps_api_object_create();

--- a/src/unit_test/nas_rt_rif_test.py
+++ b/src/unit_test/nas_rt_rif_test.py
@@ -15,7 +15,7 @@
 
 import cps
 from cps_utils import *
-import nas_ut_framework as nas_ut
+import nas_common_utils as nas_common
 import cps_object
 import nas_os_if_utils as nas_if
 import sys
@@ -60,7 +60,7 @@ def nas_vlan_op(op, data_dict):
             data_dict[intf_rpc_op_attr_id] = intf_rpc_op_type_map[op]
         obj = cps_object.CPSObject( intf_rpc_key_id, data=data_dict)
         op = 'rpc'
-    nas_ut.get_cb_method(op)(obj)
+    nas_common.get_cb_method(op)(obj)
 
 def commit(obj, op):
     l = []
@@ -78,7 +78,7 @@ def exec_shell(cmd):
 def get_sw_mode():
     global mode
     mode = 'OPX'
-    ret = exec_shell('os10-show-version | grep \"OS_NAME.*Enterprise\"')
+    ret = exec_shell('opx-show-version | grep \"OS_NAME.*Enterprise\"')
     if ret:
         mode = 'DoD'
 

--- a/src/unit_test/nas_rt_util_unittest.cpp
+++ b/src/unit_test/nas_rt_util_unittest.cpp
@@ -222,7 +222,8 @@ cps_api_return_code_t nas_ut_rt_cfg (const char *rt_vrf_name, bool is_add, const
     return cps_api_ret_code_OK;
 }
 
-cps_api_return_code_t nas_ut_rt_ipv6_nh_cfg (bool is_add, const char *ip_addr, uint32_t prefix_len, uint8_t af,
+cps_api_return_code_t nas_ut_rt_ipv6_nh_cfg (const char *rt_vrf_name, bool is_add, const char *ip_addr,
+                                             uint32_t prefix_len, uint8_t af, const char *nh_vrf_name,
                                              const char *nh_addr1, const char *if_name1,
                                              const char *nh_addr2, const char *if_name2)
 {
@@ -234,6 +235,16 @@ cps_api_return_code_t nas_ut_rt_ipv6_nh_cfg (bool is_add, const char *ip_addr, u
 
     cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
            BASE_ROUTE_ROUTE_NH_OPERATION_OBJ,cps_api_qualifier_TARGET);
+
+    if (rt_vrf_name) {
+        cps_api_object_attr_add(obj,BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_VRF_NAME, rt_vrf_name,
+                                strlen(rt_vrf_name)+1);
+    }
+    if (nh_vrf_name) {
+        cps_api_object_attr_add(obj,BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_VRF_NAME, nh_vrf_name,
+                                strlen(nh_vrf_name)+1);
+    }
+
 
     /*
      * Check mandatory route attributes
@@ -254,11 +265,19 @@ cps_api_return_code_t nas_ut_rt_ipv6_nh_cfg (bool is_add, const char *ip_addr, u
     ids[0] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST;
 
     if (if_name1) {
-        uint32_t gw_idx = if_nametoindex(if_name1);
+        if ((rt_vrf_name == NULL) ||
+            ((strlen(rt_vrf_name) == strlen("default")) &&
+             (strncmp(rt_vrf_name, "default", strlen("default")) == 0))) {
+            uint32_t gw_idx = if_nametoindex(if_name1);
+            ids[1] = 0;
+            ids[2] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST_IFINDEX;
+            cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_U32,
+                                 (void *)&gw_idx, sizeof(uint32_t));
+        }
         ids[1] = 0;
-        ids[2] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST_IFINDEX;
-        cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_U32,
-                             (void *)&gw_idx, sizeof(uint32_t));
+        ids[2] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST_IFNAME;
+        cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_BIN,
+                             (void *)if_name1, sizeof(if_name1)+1);
         nh_count = 1;
     }
     if (nh_addr1) {
@@ -274,11 +293,20 @@ cps_api_return_code_t nas_ut_rt_ipv6_nh_cfg (bool is_add, const char *ip_addr, u
     }
 
     if (if_name2) {
-        uint32_t gw_idx = if_nametoindex(if_name2);
+        if ((rt_vrf_name == NULL) ||
+            ((strlen(rt_vrf_name) == strlen("default")) &&
+             (strncmp(rt_vrf_name, "default", strlen("default")) == 0))) {
+            uint32_t gw_idx = if_nametoindex(if_name2);
+            ids[1] = 1;
+            ids[2] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST_IFINDEX;
+            cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_U32,
+                                 (void *)&gw_idx, sizeof(uint32_t));
+        }
+
         ids[1] = 1;
-        ids[2] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST_IFINDEX;
-        cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_U32,
-                             (void *)&gw_idx, sizeof(uint32_t));
+        ids[2] = BASE_ROUTE_ROUTE_NH_OPERATION_INPUT_NH_LIST_IFNAME;
+        cps_api_object_e_add(obj,ids,ids_len,cps_api_object_ATTR_T_BIN,
+                             (void *)if_name2, sizeof(if_name2)+1);
         nh_count = 2;
     }
     if (nh_addr2) {
@@ -507,7 +535,7 @@ void nas_route_dump_route_object_content(cps_api_object_t obj) {
 
 
 cps_api_return_code_t nas_ut_validate_neigh_cfg (const char *vrf_name, uint32_t af, const char *ip_addr,
-                                                 uint32_t state, bool should_exist_in_npu)
+                                                 uint32_t state, bool should_exist_in_npu, const char *nh_vrf_name)
 {
     cps_api_return_code_t rc = cps_api_ret_code_ERR;
     cps_api_get_params_t gp;
@@ -558,13 +586,33 @@ cps_api_return_code_t nas_ut_validate_neigh_cfg (const char *vrf_name, uint32_t 
                     rc = cps_api_ret_code_ERR;
                     break;
                 }
+
+                const char *nh_obj_vrf_name = (const char *)cps_api_object_get_data(obj, BASE_ROUTE_OBJ_NBR_VRF_NAME);
+                if (nh_vrf_name) {
+                    if (nh_obj_vrf_name == NULL) {
+                        rc = cps_api_ret_code_ERR;
+                        break;
+                    }
+                    if (strncmp(nh_vrf_name, nh_obj_vrf_name, strlen(nh_vrf_name))) {
+                        std::cout<<"Nbr NH Expected: "<<nh_vrf_name<<" Actual: "<<nh_obj_vrf_name<<std::endl;
+                        rc = cps_api_ret_code_ERR;
+                        break;
+                    }
+                }
                 if (should_exist_in_npu && (cps_api_object_attr_data_u32(prg_done_attr) == false)) {
+                    std::cout<<"IP nbr not exist in NPU:"<<std::endl;
                     rc = cps_api_ret_code_ERR;
                     break;
                 }
-                if (cps_api_object_attr_data_u32(state_attr) != state) {
-                    rc = cps_api_ret_code_ERR;
-                    break;
+                uint32_t state_val = cps_api_object_attr_data_u32(state_attr);
+                if (state_val != state) {
+                    if ((state == 2) && (state_val == 4)) {
+                        /* Sometimes state is 4 (stale) instead of 2 (reachable), this is expected during refresh in progress. */
+                    } else {
+                        std::cout<<"Nbr state Expected: "<<state<<" Actual: "<<state_val<<std::endl;
+                        rc = cps_api_ret_code_ERR;
+                        break;
+                    }
                 }
             }
         }
@@ -616,6 +664,93 @@ cps_api_return_code_t nas_ut_validate_rt_cfg (const char *rt_vrf_name, uint32_t 
             std::cout<<"================================="<<std::endl;
             for ( size_t ix = 0 ; ix < mx ; ++ix ) {
                 obj = cps_api_object_list_get(gp.list,ix);
+
+                const char *nh_obj_vrf_name = (const char *)cps_api_object_get_data(obj, BASE_ROUTE_OBJ_ENTRY_NH_VRF_NAME);
+                if (nh_vrf_name) {
+                    if (nh_obj_vrf_name == NULL) {
+                        rc = cps_api_ret_code_ERR;
+                        break;
+                    }
+                    if (strncmp(nh_vrf_name, nh_obj_vrf_name, strlen(nh_vrf_name))) {
+                        std::cout<<"Route NH Expected: "<<nh_vrf_name<<" Actual: "<<nh_obj_vrf_name<<std::endl;
+                        rc = cps_api_ret_code_ERR;
+                        break;
+                    }
+                }
+
+                cps_api_object_attr_t prg_done = cps_api_object_attr_get(obj,
+                                                                         BASE_ROUTE_OBJ_ENTRY_NPU_PRG_DONE);
+                if (prg_done && (cps_api_object_attr_data_u32(prg_done))) {
+                    if (should_exist_in_npu == false) {
+                        std::cout<<"IP route not exist in NPU:"<<std::endl;
+                        rc = cps_api_ret_code_ERR;
+                    }
+                } else {
+                    if (should_exist_in_npu) {
+                        std::cout<<"IP route exists in NPU:"<<std::endl;
+                        rc = cps_api_ret_code_ERR;
+                    }
+                }
+                nas_route_dump_route_object_content(obj);
+                std::cout<<std::endl;
+            }
+        }
+    }
+
+    cps_api_get_request_close(&gp);
+    return rc;
+}
+
+cps_api_return_code_t nas_ut_validate_rt_ecmp_cfg (const char *rt_vrf_name, uint32_t af, const char *ip_addr, uint32_t prefix_len,
+                                              const char *nh_vrf_name, const char *nh_addr, const char *if_name, bool should_exist_in_npu, uint32_t rt_nh_cnt)
+{
+    cps_api_return_code_t rc = cps_api_ret_code_ERR;
+    cps_api_get_params_t gp;
+    cps_api_get_request_init(&gp);
+
+    cps_api_object_t obj = cps_api_object_list_create_obj_and_append(gp.filters);
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),BASE_ROUTE_OBJ_ENTRY,
+                                    cps_api_qualifier_TARGET);
+
+    cps_api_set_key_data(obj,BASE_ROUTE_OBJ_VRF_NAME, cps_api_object_ATTR_T_BIN, rt_vrf_name,
+                         strlen(rt_vrf_name)+1);
+    cps_api_set_key_data(obj,BASE_ROUTE_OBJ_ENTRY_AF,cps_api_object_ATTR_T_U32,
+                         &af,sizeof(af));
+
+    if (af == AF_INET) {
+        uint32_t ip;
+        struct in_addr a;
+        inet_aton(ip_addr, &a);
+        ip=a.s_addr;
+
+        cps_api_set_key_data(obj,BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,cps_api_object_ATTR_T_BIN, &ip,sizeof(ip));
+    } else if (af == AF_INET6) {
+        struct in6_addr a6;
+        inet_pton(AF_INET6, ip_addr, &a6);
+
+        cps_api_set_key_data (obj,BASE_ROUTE_OBJ_ENTRY_ROUTE_PREFIX,cps_api_object_ATTR_T_BIN, &a6,sizeof(struct in6_addr));
+    }
+    cps_api_set_key_data (obj,BASE_ROUTE_OBJ_ENTRY_PREFIX_LEN, cps_api_object_ATTR_T_U32, &prefix_len, sizeof (prefix_len));
+
+    if (cps_api_get(&gp)==cps_api_ret_code_OK) {
+        size_t mx = cps_api_object_list_size(gp.list);
+        if (mx)
+        {
+            rc = cps_api_ret_code_OK;
+            std::cout<<"Route get successful"<<std::endl;
+            cps_api_object_attr_t nh_count = cps_api_object_attr_get(obj, BASE_ROUTE_OBJ_ENTRY_NH_COUNT);
+            if (nh_count) {
+                uint32_t nhc = cps_api_object_attr_data_u32(nh_count);
+            std::cout<<"Route get successful"<<nhc<<std::endl;
+                if (nhc != rt_nh_cnt) {
+                    cps_api_get_request_close(&gp);
+                    return (cps_api_ret_code_ERR);
+                }
+            }
+            std::cout<<"IP FIB Entries, Family:"<<af<<std::endl;
+            std::cout<<"================================="<<std::endl;
+            for ( size_t ix = 0 ; ix < mx ; ++ix ) {
+                obj = cps_api_object_list_get(gp.list,ix);
                 cps_api_object_attr_t prg_done = cps_api_object_attr_get(obj,
                                                                          BASE_ROUTE_OBJ_ENTRY_NPU_PRG_DONE);
                 if (prg_done && (cps_api_object_attr_data_u32(prg_done))) {
@@ -638,6 +773,7 @@ cps_api_return_code_t nas_ut_validate_rt_cfg (const char *rt_vrf_name, uint32_t 
     cps_api_get_request_close(&gp);
     return rc;
 }
+
 
 cps_api_return_code_t nas_ut_route_op_spl_nh (bool is_add, const char *vrf_name, const char *ip_addr, uint32_t prefix_len,
                              uint32_t spl_nh_option, uint8_t af)

--- a/src/unit_test/nas_rt_util_unittest.h
+++ b/src/unit_test/nas_rt_util_unittest.h
@@ -36,12 +36,18 @@ cps_api_return_code_t nas_ut_rt_cfg (const char *rt_vrf_name, bool is_add, const
 cps_api_return_code_t nas_ut_neigh_cfg (bool is_add, const char *ip_addr, uint8_t af, const char *if_name, hal_mac_addr_t *hw_addr);
 void nas_route_dump_arp_object_content(cps_api_object_t obj);
 cps_api_return_code_t nas_ut_validate_neigh_cfg (const char *vrf_name, uint32_t af, const char *ip_addr,
-                                                 uint32_t state, bool should_exist_in_npu);
+                                                 uint32_t state, bool should_exist_in_npu, const char *nh_vrf_name);
 cps_api_return_code_t nas_ut_validate_rt_cfg (const char *rt_vrf_name, uint32_t af, const char *ip_addr, uint32_t prefix_len,
                                               const char *nh_vrf_name, const char *nh_addr, const char *if_name, bool should_exist_in_npu);
+cps_api_return_code_t nas_ut_validate_rt_ecmp_cfg (const char *rt_vrf_name, uint32_t af, const char *ip_addr, uint32_t prefix_len,
+                                              const char *nh_vrf_name, const char *nh_addr, const char *if_name, bool should_exist_in_npu,
+                                              uint32_t rt_nh_cnt);
 void nas_route_dump_route_object_content(cps_api_object_t obj);
-cps_api_return_code_t nas_ut_rt_ipv6_nh_cfg (bool is_add, const char *ip_addr, uint32_t prefix_len, uint8_t af,
-                                             const char *nh_addr1, const char *if_name1, const char *nh_addr2, const char *if_name2);
+
+cps_api_return_code_t nas_ut_rt_ipv6_nh_cfg (const char *rt_vrf_name, bool is_add, const char *ip_addr,
+                                             uint32_t prefix_len, uint8_t af, const char *nh_vrf_name,
+                                             const char *nh_addr1, const char *if_name1,
+                                             const char *nh_addr2, const char *if_name2);
 cps_api_return_code_t nas_ut_vrf_cfg (const char *vrf_name, bool is_add);
 cps_api_return_code_t nas_ut_intf_vrf_cfg (const char *vrf_name, const char *if_name, bool is_add);
 cps_api_return_code_t nas_ut_intf_mgmt_vrf_cfg(const char *vrf_name, const char *if_name, bool is_add);

--- a/src/unit_test/nas_rt_vrf_unittest.cpp
+++ b/src/unit_test/nas_rt_vrf_unittest.cpp
@@ -19,7 +19,9 @@
  */
 #include "nas_rt_util_unittest.h"
 #include "dell-base-routing.h"
+#include "vrf-mgmt.h"
 
+#include <arpa/inet.h>
 #include <gtest/gtest.h>
 #include <iostream>
 #include "sys/time.h"
@@ -32,6 +34,10 @@ const char *b2b_intf1 = "e101-019-0";
 const char *b2b_intf2 = "e101-020-0";
 const char *DoD_b2b_intf1 = "1/1/19";
 const char *DoD_b2b_intf2 = "1/1/20";
+
+const char *b2b_leak_intf1 = "e101-001-0";
+const char *b2b_leak_vrf_intf1 = "v-e101-001-0";
+const char *DoD_b2b_leak_intf1 = "1/1/1";
 
 void print_time(char *buffer, int *p_sec, int *p_milli_sec)
 {
@@ -85,9 +91,183 @@ static void nas_vrf_change_mode(bool is_l3) {
         fprintf(fp, "exit\n");
         fflush(fp);
         system("sudo -u admin clish --b /tmp/test_pre_req");
+
+        fclose(fp);
     }
 }
 
+static void nas_rt_dump_nht_object_content(cps_api_object_t obj){
+    char str[INET6_ADDRSTRLEN];
+    uint32_t addr_len = 0, af_data = 0;
+    uint32_t nhc = 0, nh_itr = 0;
+
+    const char *vrf_name = (const char *)cps_api_object_get_data(obj, BASE_ROUTE_NH_TRACK_VRF_NAME);
+    if (vrf_name) {
+        std::cout<<"VRF name "<<vrf_name<<std::endl;
+    }
+    const char *nh_vrf_name = (const char *)cps_api_object_get_data(obj, BASE_ROUTE_NH_TRACK_NH_INFO_VRF_NAME);
+    if (nh_vrf_name) {
+        std::cout<<"NH VRF name "<<nh_vrf_name<<std::endl;
+    }
+    cps_api_object_attr_t af_attr = cps_api_get_key_data(obj, BASE_ROUTE_NH_TRACK_AF);
+    if (af_attr != CPS_API_ATTR_NULL) {
+        af_data = cps_api_object_attr_data_u32(af_attr) ;
+        std::cout<<"Address Family "<<((af_data == AF_INET) ? "IPv4" : "IPv6")<<std::endl;
+        addr_len = ((af_data == AF_INET) ? INET_ADDRSTRLEN : INET6_ADDRSTRLEN);
+    }
+
+    cps_api_object_attr_t dest_attr = cps_api_get_key_data(obj, BASE_ROUTE_NH_TRACK_DEST_ADDR);
+    if (dest_attr != CPS_API_ATTR_NULL) {
+        std::cout<<"Dest Address "<<inet_ntop(af_data,cps_api_object_attr_data_bin(dest_attr),str,addr_len)<<std::endl;
+    }
+
+    cps_api_object_attr_t nh_count_attr = cps_api_object_attr_get(obj, BASE_ROUTE_NH_TRACK_NH_COUNT);
+    if (nh_count_attr != CPS_API_ATTR_NULL) {
+        nhc = cps_api_object_attr_data_u32(nh_count_attr);
+        std::cout<<"NH Count "<<nhc<<std::endl;
+    }
+
+    for (nh_itr = 0; nh_itr < nhc; nh_itr++)
+    {
+        cps_api_attr_id_t ids[3] = { BASE_ROUTE_NH_TRACK_NH_INFO,
+            0, BASE_ROUTE_NH_TRACK_NH_INFO_ADDRESS};
+        const int ids_len = sizeof(ids)/sizeof(*ids);
+
+        ids[1] = nh_itr;
+
+        cps_api_object_attr_t attr = cps_api_object_e_get(obj,ids,ids_len);
+        if (attr != CPS_API_ATTR_NULL)
+            std::cout<<"NextHop IP "<<inet_ntop(af_data,cps_api_object_attr_data_bin(attr),str,addr_len)<<std::endl;
+
+        ids[2] = BASE_ROUTE_NH_TRACK_NH_INFO_MAC_ADDR;
+        attr = cps_api_object_e_get(obj,ids,ids_len);
+        if (attr != CPS_API_ATTR_NULL)
+        {
+            char mt[6];
+            char mstring[20];
+            memcpy(mt, cps_api_object_attr_data_bin(attr), 6);
+            snprintf(mstring, 19, "%x:%x:%x:%x:%x:%x", mt[0], mt[1], mt[2], mt[3], mt[4], mt[5]);
+            std::cout<<"NextHop MAC "<<mstring<<std::endl;
+        }
+
+//      ids[2] = BASE_ROUTE_NH_TRACK_NH_INFO_AF;
+//      attr = cps_api_object_e_get(obj,ids,ids_len);
+//      if (attr != CPS_API_ATTR_NULL)
+//          std::cout<<"NextHop Address family "<<cps_api_object_attr_data_u32(attr)<<std::endl;
+
+
+        ids[2] = BASE_ROUTE_NH_TRACK_NH_INFO_IFINDEX;
+        attr = cps_api_object_e_get(obj,ids,ids_len);
+        if (attr != CPS_API_ATTR_NULL) {
+            std::cout<<"IfIndex:" <<cps_api_object_attr_data_u32(attr)<<std::endl;
+        }
+
+        ids[2] = BASE_ROUTE_OBJ_ENTRY_NH_LIST_RESOLVED;
+        attr = cps_api_object_e_get(obj,ids,ids_len);
+        if (attr != CPS_API_ATTR_NULL)
+            std::cout<<"Is Next Hop Resolved "<<cps_api_object_attr_data_u32(attr)<<std::endl;
+    }
+}
+
+static cps_api_return_code_t nas_rt_nht_validate(const char *vrf_name, const char *ip_str, uint32_t af_family, bool is_resolved) {
+    cps_api_get_params_t gp;
+    cps_api_get_request_init(&gp);
+
+    cps_api_return_code_t rc = cps_api_ret_code_ERR;
+    struct in_addr a;
+    struct in6_addr a6;
+
+    if (af_family == AF_INET6) {
+        inet_pton(AF_INET6, ip_str, &a6);
+    } else {
+        inet_aton(ip_str,&a);
+    }
+
+    cps_api_object_t obj = cps_api_object_list_create_obj_and_append(gp.filters);
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),BASE_ROUTE_NH_TRACK_OBJ,
+                                    cps_api_qualifier_TARGET);
+
+    cps_api_object_attr_add(obj, BASE_ROUTE_NH_TRACK_VRF_NAME, vrf_name, strlen(vrf_name) + 1);
+
+    cps_api_set_key_data (obj, BASE_ROUTE_NH_TRACK_AF, cps_api_object_ATTR_T_U32,&af_family, sizeof(af_family));
+    if (af_family == AF_INET6) {
+        cps_api_set_key_data (obj, BASE_ROUTE_NH_TRACK_DEST_ADDR, cps_api_object_ATTR_T_BIN,&a6, sizeof(a6));
+    } else {
+        cps_api_set_key_data (obj, BASE_ROUTE_NH_TRACK_DEST_ADDR, cps_api_object_ATTR_T_BIN,&a, sizeof(a));
+    }
+
+    if (cps_api_get(&gp)==cps_api_ret_code_OK) {
+        size_t mx = cps_api_object_list_size(gp.list);
+        for ( size_t ix = 0 ; ix < mx ; ++ix ) {
+            rc = cps_api_ret_code_OK;
+            obj = cps_api_object_list_get(gp.list,ix);
+            std::cout<<"NAS NHT ENTRY"<<std::endl;
+            std::cout<<"============="<<std::endl;
+            nas_rt_dump_nht_object_content(obj);
+            std::cout<<std::endl;
+
+            cps_api_object_attr_t nh_count_attr = cps_api_object_attr_get(obj, BASE_ROUTE_NH_TRACK_NH_COUNT);
+            if (nh_count_attr != CPS_API_ATTR_NULL) {
+                uint32_t nhc = cps_api_object_attr_data_u32(nh_count_attr);
+                if ((nhc && (is_resolved == false)) || (nhc == 0 && is_resolved)) {
+                    std::cout<<"NAS NHT Error - NHC:"<<nhc<<"resolved:"<<is_resolved<<std::endl;
+                    rc = cps_api_ret_code_ERR;
+                    break;
+                }
+            } else if (is_resolved) {
+                std::cout<<"NAS NHT Error nh_count is not present"<<std::endl;
+                rc = cps_api_ret_code_ERR;
+                break;
+            }
+        }
+    }
+    cps_api_get_request_close(&gp);
+    return rc;
+}
+
+static void nas_rt_nht_add_del(const char *vrf_name, void *nht_dest, uint32_t af_family, bool is_add)
+{
+    uint32_t ip;
+    cps_api_transaction_params_t tr;
+
+    cps_api_object_t obj = cps_api_object_create();
+    cps_api_key_from_attr_with_qual(cps_api_object_key(obj),
+                                    BASE_ROUTE_NH_TRACK_OBJ,cps_api_qualifier_TARGET);
+
+    cps_api_object_attr_add(obj, BASE_ROUTE_NH_TRACK_VRF_NAME,
+                            vrf_name, strlen(vrf_name) + 1);
+    cps_api_set_key_data (obj, BASE_ROUTE_NH_TRACK_AF, cps_api_object_ATTR_T_U32,&af_family, sizeof(af_family));
+    if (af_family == AF_INET6) {
+        cps_api_set_key_data (obj, BASE_ROUTE_NH_TRACK_DEST_ADDR, cps_api_object_ATTR_T_BIN,
+                              (struct in6_addr *) nht_dest,sizeof(struct in6_addr));
+    } else {
+        ip=((struct in_addr *) nht_dest)->s_addr;
+        cps_api_set_key_data (obj, BASE_ROUTE_NH_TRACK_DEST_ADDR, cps_api_object_ATTR_T_BIN,&ip, sizeof(ip));
+    }
+
+    ASSERT_TRUE(cps_api_transaction_init(&tr)==cps_api_ret_code_OK);
+    if (is_add) {
+        cps_api_create(&tr,obj);
+    } else {
+        cps_api_delete(&tr,obj);
+    }
+    ASSERT_TRUE(cps_api_commit(&tr)==cps_api_ret_code_OK);
+    cps_api_transaction_close(&tr);
+}
+
+static void nas_rt_nht_config(const char *vrf_name, const char *ip_str, uint32_t af_family, bool is_add)
+{
+    struct in_addr a;
+    struct in6_addr a6;
+
+    if (af_family == AF_INET6) {
+        inet_pton(AF_INET6, ip_str, &a6);
+        nas_rt_nht_add_del (vrf_name, (void *) &a6, af_family, is_add);
+    } else {
+        inet_aton(ip_str,&a);
+        nas_rt_nht_add_del (vrf_name, (void *) &a, af_family, is_add);
+    }
+}
 
 static void nas_rt_special_next_hop_config(bool is_add, const char *vrf_name) {
     cps_api_return_code_t rc;
@@ -221,7 +401,7 @@ static void nas_rt_scal_test(int start_vrf_id, int no_of_vrfs, bool is_add, cps_
         ASSERT_TRUE(rc == rc_check);
         rc = nas_ut_validate_rt_cfg (vrf, AF_INET, "100.0.0.0", 24, vrf, "", "", true);
         ASSERT_TRUE(rc == rc_check);
-        rc = nas_ut_validate_neigh_cfg(vrf, AF_INET, "100.0.0.2", 128, true);
+        rc = nas_ut_validate_neigh_cfg(vrf, AF_INET, "100.0.0.2", 128, true, NULL);
         ASSERT_TRUE(rc == rc_check);
         rc = nas_ut_validate_rt_cfg (vrf, AF_INET, "60.0.0.0", 8, vrf, "", "", true);
         ASSERT_TRUE(rc == rc_check);
@@ -229,7 +409,7 @@ static void nas_rt_scal_test(int start_vrf_id, int no_of_vrfs, bool is_add, cps_
         ASSERT_TRUE(rc == rc_check);
         rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "100::0", 64, vrf, "", "", true);
         ASSERT_TRUE(rc == rc_check);
-        rc = nas_ut_validate_neigh_cfg(vrf, AF_INET6, "100::2", 128, true);
+        rc = nas_ut_validate_neigh_cfg(vrf, AF_INET6, "100::2", 128, true, NULL);
         ASSERT_TRUE(rc == rc_check);
         rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "60::0", 64, vrf, "", "", true);
         ASSERT_TRUE(rc == rc_check);
@@ -278,7 +458,7 @@ static void nas_rt_scal_neigh_test(int start_vrf_id, int no_of_vrfs, int scal_ar
             if (is_neg_test == false) {
                 for (itr = 2; itr <= (scal_arp_limit +1); itr++) {
                     memset(cmd, '\0', sizeof(cmd));
-                    snprintf(cmd, 511, "/opt/opx/bin/cps_config_mac.py delete vlan %d port %s 00:11:22:33:44:%02x static", id, b2b_intf1, itr);
+                    snprintf(cmd, 511, "/usr/bin/cps_config_mac.py delete vlan %d port %s 00:11:22:33:44:%02x static", id, b2b_intf1, itr);
                     system(cmd);
                 }
             }
@@ -368,12 +548,12 @@ static void nas_rt_scal_neigh_test(int start_vrf_id, int no_of_vrfs, int scal_ar
         for (itr = 2; itr <= (scal_arp_limit +1); itr++) {
             memset(ip, '\0', sizeof(ip));
             snprintf(ip, sizeof(ip), "100.0.0.%d", itr);
-            rc = nas_ut_validate_neigh_cfg(vrf, AF_INET, ip, 128, true);
+            rc = nas_ut_validate_neigh_cfg(vrf, AF_INET, ip, 128, true, NULL);
             ASSERT_TRUE(rc == rc_check);
             if (itr <= (scal_neigh_limit+1)) {
                 memset(ip, '\0', sizeof(ip));
                 snprintf(ip, sizeof(ip), "100::%x", itr);
-                rc = nas_ut_validate_neigh_cfg(vrf, AF_INET6, ip, 128, true);
+                rc = nas_ut_validate_neigh_cfg(vrf, AF_INET6, ip, 128, true, NULL);
                 ASSERT_TRUE(rc == rc_check);
             }
         }
@@ -395,6 +575,121 @@ static void nas_rt_cleanup() {
     memset(cmd, '\0', sizeof(cmd));
     snprintf(cmd, 511, "ip link set dev %s up", b2b_intf2);
     system(cmd);
+}
+
+static bool nas_vrf_src_ip_config (bool is_add, const char * vrf_name, uint32_t af, const char * ip_addr)
+{
+    cps_api_transaction_params_t params;
+    cps_api_object_t             obj;
+    cps_api_key_t                keys;
+    bool                         rc = true;
+
+    do {
+        if ((obj = cps_api_object_create()) == NULL) {
+            rc = false;
+            break;
+        }
+        cps_api_object_guard obj_g (obj);
+        if (cps_api_transaction_init(&params) != cps_api_ret_code_OK) {
+            rc = false;
+            break;
+        }
+        cps_api_transaction_guard tgd(&params);
+        cps_api_key_from_attr_with_qual(&keys, VRF_MGMT_SRC_IP_CONFIG_OBJ,
+                                        cps_api_qualifier_TARGET);
+        cps_api_object_set_key(obj, &keys);
+
+        cps_api_object_attr_add(obj, VRF_MGMT_SRC_IP_CONFIG_INPUT_NI_NAME,
+                                vrf_name, strlen(vrf_name) + 1);
+        cps_api_object_attr_add_u32(obj, VRF_MGMT_SRC_IP_CONFIG_INPUT_OPERATION,
+                                    (is_add ? BASE_CMN_OPERATION_TYPE_CREATE : BASE_CMN_OPERATION_TYPE_DELETE));
+
+        if (af == AF_INET) {
+            cps_api_object_attr_add_u32(obj,VRF_MGMT_SRC_IP_CONFIG_INPUT_AF,AF_INET);
+
+            uint32_t ip;
+            struct in_addr a;
+            inet_aton(ip_addr, &a);
+            ip=a.s_addr;
+
+            cps_api_object_attr_add(obj,VRF_MGMT_SRC_IP_CONFIG_INPUT_SRC_IP,&ip,sizeof(ip));
+        } else if (af == AF_INET6) {
+            cps_api_object_attr_add_u32(obj,VRF_MGMT_SRC_IP_CONFIG_INPUT_AF,AF_INET6);
+
+            struct in6_addr a6;
+            inet_pton(AF_INET6, ip_addr, &a6);
+
+            cps_api_object_attr_add(obj,VRF_MGMT_SRC_IP_CONFIG_INPUT_SRC_IP,&a6,sizeof(struct in6_addr));
+        }
+
+        if (cps_api_action(&params, obj) != cps_api_ret_code_OK) {
+            rc = false;
+            break;
+        }
+
+        obj_g.release();
+
+        if (cps_api_commit(&params) != cps_api_ret_code_OK) {
+            rc = false;
+            break;
+        }
+
+    } while (false);
+
+    return rc;
+}
+
+static bool nas_vrf_neigh_flush (const char * vrf_name, uint32_t af, const char *if_name)
+{
+    cps_api_transaction_params_t params;
+    cps_api_object_t             obj;
+    cps_api_key_t                keys;
+    bool                         rc = true;
+
+    do {
+        if ((obj = cps_api_object_create()) == NULL) {
+            rc = false;
+            break;
+        }
+        cps_api_object_guard obj_g (obj);
+        if (cps_api_transaction_init(&params) != cps_api_ret_code_OK) {
+            rc = false;
+            break;
+        }
+        cps_api_transaction_guard tgd(&params);
+        cps_api_key_from_attr_with_qual(&keys, BASE_ROUTE_NBR_FLUSH_OBJ,
+                                        cps_api_qualifier_TARGET);
+        cps_api_object_set_key(obj, &keys);
+
+        cps_api_object_attr_add(obj, BASE_ROUTE_NBR_FLUSH_INPUT_VRF_NAME,
+                                vrf_name, strlen(vrf_name) + 1);
+
+        if (af == AF_INET) {
+            cps_api_object_attr_add_u32(obj,BASE_ROUTE_NBR_FLUSH_INPUT_AF,AF_INET);
+        } else if (af == AF_INET6) {
+            cps_api_object_attr_add_u32(obj,BASE_ROUTE_NBR_FLUSH_INPUT_AF,AF_INET6);
+        }
+
+        if (if_name) {
+            cps_api_object_attr_add(obj, BASE_ROUTE_NBR_FLUSH_INPUT_IFNAME,
+                                    if_name, strlen(if_name) + 1);
+        }
+
+        if (cps_api_action(&params, obj) != cps_api_ret_code_OK) {
+            rc = false;
+            break;
+        }
+
+        obj_g.release();
+
+        if (cps_api_commit(&params) != cps_api_ret_code_OK) {
+            rc = false;
+            break;
+        }
+
+    } while (false);
+
+    return rc;
 }
 
 static void nas_rt_validate_blue_vrf_config(cps_api_return_code_t rc_check) {
@@ -426,13 +721,13 @@ static void nas_rt_validate_blue_vrf_config(cps_api_return_code_t rc_check) {
     rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "4444::0", 64, "blue", "", "", true);
     ASSERT_TRUE(rc == rc_check);
 
-    rc = nas_ut_validate_neigh_cfg("default", 2, "30.0.0.2", 2, true);
+    rc = nas_ut_validate_neigh_cfg("default", 2, "30.0.0.2", 2, true, NULL);
     ASSERT_TRUE(rc == rc_check);
-    rc = nas_ut_validate_neigh_cfg("default", 10, "3333::2", 2, true);
+    rc = nas_ut_validate_neigh_cfg("default", 10, "3333::2", 2, true, NULL);
     ASSERT_TRUE(rc == rc_check);
-    rc = nas_ut_validate_neigh_cfg("blue", 2, "30.0.0.1", 2, true);
+    rc = nas_ut_validate_neigh_cfg("blue", 2, "30.0.0.1", 2, true, NULL);
     ASSERT_TRUE(rc == rc_check);
-    rc = nas_ut_validate_neigh_cfg("blue", 10, "3333::1", 2, true);
+    rc = nas_ut_validate_neigh_cfg("blue", 10, "3333::1", 2, true, NULL);
     ASSERT_TRUE(rc == rc_check);
 }
 
@@ -466,13 +761,13 @@ static void nas_rt_validate_red_vrf_config(cps_api_return_code_t rc_check) {
     rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "4444::0", 64, "default", "", "", true);
     ASSERT_TRUE(rc == rc_check);
 
-    rc = nas_ut_validate_neigh_cfg("red", 2, "30.0.0.2", 2, true);
+    rc = nas_ut_validate_neigh_cfg("red", 2, "30.0.0.2", 2, true, NULL);
     ASSERT_TRUE(rc == rc_check);
-    rc = nas_ut_validate_neigh_cfg("red", 10, "3333::2", 2, true);
+    rc = nas_ut_validate_neigh_cfg("red", 10, "3333::2", 2, true, NULL);
     ASSERT_TRUE(rc == rc_check);
-    rc = nas_ut_validate_neigh_cfg("default", 2, "30.0.0.1", 2, true);
+    rc = nas_ut_validate_neigh_cfg("default", 2, "30.0.0.1", 2, true, NULL);
     ASSERT_TRUE(rc == rc_check);
-    rc = nas_ut_validate_neigh_cfg("default", 10, "3333::1", 2, true);
+    rc = nas_ut_validate_neigh_cfg("default", 10, "3333::1", 2, true, NULL);
     ASSERT_TRUE(rc == rc_check);
 }
 
@@ -820,6 +1115,1435 @@ TEST(nas_rt_vrf_test, nas_rt_basic_phy_vrf) {
     nas_rt_cleanup();
 }
 
+
+static void nas_rt_validate_leak_from_default_vrf_parent_conn_rt(bool is_add) {
+    cps_api_return_code_t rc, rc_check = (is_add ? cps_api_ret_code_OK : cps_api_ret_code_ERR);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "20.0.0.0", 16, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "20::", 64, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+}
+
+static void nas_rt_validate_leak_from_default_vrf_parent_reg_rt(bool is_add) {
+    cps_api_return_code_t rc, rc_check = (is_add ? cps_api_ret_code_OK : cps_api_ret_code_ERR);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "80.0.0.0", 16, "default", "20.0.0.2", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "80::", 64, "default", "20::2", "", true);
+    ASSERT_TRUE(rc == rc_check);
+}
+
+static void nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(bool is_add) {
+    cps_api_return_code_t rc, rc_check = (is_add ? cps_api_ret_code_OK : cps_api_ret_code_ERR);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET, "80.0.0.0", 16, "default", "20.0.0.2", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "80::", 64, "default", "20::2", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET, "80.0.0.0", 16, "default", "20.0.0.2", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "80::", 64, "default", "20::2", "", true);
+    ASSERT_TRUE(rc == rc_check);
+}
+
+static void nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(bool is_add) {
+    cps_api_return_code_t rc, rc_check = (is_add ? cps_api_ret_code_OK : cps_api_ret_code_ERR);
+
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET, "20.0.0.0", 16, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "20::", 64, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET, "20.0.0.0", 16, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "20::", 64, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+}
+
+static void nas_rt_validate_leak_from_default_vrf_leaked_rt_loopbk_intf(bool is_add) {
+    cps_api_return_code_t rc, rc_check = (is_add ? cps_api_ret_code_OK : cps_api_ret_code_ERR);
+
+    /* Loopback interface IPs */
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET, "50.0.0.1", 32, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "50::1", 128, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET, "60.0.0.1", 32, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "60::1", 128, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+
+    /* Leak routes from blue and red VRFs to default */
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "50.0.0.1", 32, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "50::1", 128, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "60.0.0.1", 32, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "60::1", 128, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+}
+
+static void nas_rt_validate_leak_route_from_green_vrf(cps_api_return_code_t rc_check, cps_api_return_code_t leaked_rt_rc) {
+    cps_api_return_code_t rc;
+    sleep(5);
+    rc = nas_ut_validate_rt_cfg ("green", AF_INET, "20.0.0.0", 16, "green", "", "", true);
+    ASSERT_TRUE(rc == leaked_rt_rc);
+    rc = nas_ut_validate_rt_cfg ("green", AF_INET6, "20::", 64, "green", "", "", true);
+    ASSERT_TRUE(rc == leaked_rt_rc);
+    rc = nas_ut_validate_rt_cfg ("green", AF_INET, "50.0.0.1", 32, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("green", AF_INET6, "50::1", 128, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("green", AF_INET, "60.0.0.1", 32, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("green", AF_INET6, "60::1", 128, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("green", AF_INET, "70.0.0.1", 32, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("green", AF_INET6, "70::1", 128, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET, "20.0.0.0", 16, "green", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "20::", 64, "green", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET, "50.0.0.1", 32, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "50::1", 128, "blue", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET, "20.0.0.0", 16, "green", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "20::", 64, "green", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET, "60.0.0.1", 32, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "60::1", 128, "red", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "20.0.0.0", 16, "green", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "20::", 64, "green", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET, "70.0.0.1", 32, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "70::1", 128, "default", "", "", true);
+    ASSERT_TRUE(rc == rc_check);
+}
+
+static void nas_rt_ping_from_leak_vrfs_via_default_vrf(bool ping_should_work, const char *nh_vrf_name,
+                                                       bool clean_up = false, bool parent_nbr_chk = true) {
+    if (ping_should_work) {
+        printf("\r\nVerify that ping to [20.0.0.2 and 20::2] (leaked n/w) from blue and red VRF via default/green VRF working\r\n");
+    } else {
+        printf("\r\nVerify that ping to [20.0.0.2 and 20::2] (leaked n/w) from blue and red VRF via default/green VRF NOT working\r\n");
+    }
+    printf("ip netns exec blue ping -c 3 20.0.0.2\r\n");
+    int val = system("ip netns exec blue ping -c 3 20.0.0.2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+    printf("ip netns exec blue ping -c 3 20::2\r\n");
+    val = system("ip netns exec blue ping -c 3 20::2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ip netns exec red ping -c 3 20.0.0.2\r\n");
+    val = system("ip netns exec red ping -c 3 20.0.0.2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ip netns exec red ping -c 3 20::2\r\n");
+    val = system("ip netns exec red ping -c 3 20::2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+
+    printf("ip netns exec blue ping -c 3 80.0.0.2\r\n");
+    val = system("ip netns exec blue ping -c 3 80.0.0.2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+    printf("ip netns exec blue ping -c 3 80::2\r\n");
+    val = system("ip netns exec blue ping -c 3 80::2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ip netns exec red ping -c 3 80.0.0.2\r\n");
+    val = system("ip netns exec red ping -c 3 80.0.0.2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ip netns exec red ping -c 3 80::2\r\n");
+    val = system("ip netns exec red ping -c 3 80::2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    sleep(5);
+    cps_api_return_code_t rc = cps_api_ret_code_OK, rc_check = cps_api_ret_code_OK;
+    if (!ping_should_work) {
+        rc_check = cps_api_ret_code_ERR;
+    }
+
+    if (parent_nbr_chk) {
+        rc = nas_ut_validate_neigh_cfg(nh_vrf_name, AF_INET, "20.0.0.2", 2, ping_should_work, nh_vrf_name);
+        ASSERT_TRUE(rc == rc_check);
+        rc = nas_ut_validate_neigh_cfg(nh_vrf_name, AF_INET6, "20::2", 2, ping_should_work, nh_vrf_name);
+        ASSERT_TRUE(rc == rc_check);
+    } else {
+        return;
+    }
+    rc = nas_ut_validate_neigh_cfg("blue", AF_INET, "20.0.0.2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("red", AF_INET, "20.0.0.2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("blue", AF_INET6, "20::2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("red", AF_INET6, "20::2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+
+    cps_api_return_code_t nht_rc = cps_api_ret_code_OK;
+
+    if (clean_up) {
+        nht_rc = cps_api_ret_code_ERR;
+    }
+    rc = nas_rt_nht_validate("blue", "20.0.0.2", 2, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("blue", "20::2", 10, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("red", "20.0.0.2", 2, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("red", "20::2", 10, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+
+    if (parent_nbr_chk) {
+        rc = nas_rt_nht_validate(nh_vrf_name, "20.0.0.2", 2, ping_should_work);
+        ASSERT_TRUE(rc == nht_rc);
+        rc = nas_rt_nht_validate(nh_vrf_name, "20::2", 10, ping_should_work);
+        ASSERT_TRUE(rc == nht_rc);
+
+        rc = nas_rt_nht_validate("blue", "80.0.0.2", 2, ping_should_work);
+        ASSERT_TRUE(rc == nht_rc);
+        rc = nas_rt_nht_validate("blue", "80::2", 10, ping_should_work);
+        ASSERT_TRUE(rc == nht_rc);
+        rc = nas_rt_nht_validate("red", "80.0.0.2", 2, ping_should_work);
+        ASSERT_TRUE(rc == nht_rc);
+        rc = nas_rt_nht_validate("red", "80::2", 10, ping_should_work);
+        ASSERT_TRUE(rc == nht_rc);
+    }
+}
+
+static void nas_rt_ping_from_leak_vrfs_via_default_vrf_ext(bool ping_should_work, const char *nh_vrf_name,
+                                                           bool leak_neigh_should_present = true) {
+    if (ping_should_work) {
+        printf("\r\nVerify that ping to [20.0.0.2 and 20::2] (leaked n/w) from blue and red VRF via default/green VRF working\r\n");
+    } else {
+        printf("\r\nVerify that ping to [20.0.0.2 and 20::2] (leaked n/w) from blue and red VRF via default/green VRF NOT working\r\n");
+    }
+    printf("ip netns exec blue ping -c 3 20.0.0.2\r\n");
+    int val = system("ip netns exec blue ping -c 3 20.0.0.2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+    printf("ip netns exec blue ping -c 3 20::2\r\n");
+    val = system("ip netns exec blue ping -c 3 20::2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ip netns exec red ping -c 3 20.0.0.2\r\n");
+    val = system("ip netns exec red ping -c 3 20.0.0.2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ip netns exec red ping -c 3 20::2\r\n");
+    val = system("ip netns exec red ping -c 3 20::2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+
+    printf("ip netns exec blue ping -c 3 80.0.0.2\r\n");
+    val = system("ip netns exec blue ping -c 3 80.0.0.2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+    printf("ip netns exec blue ping -c 3 80::2\r\n");
+    val = system("ip netns exec blue ping -c 3 80::2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ip netns exec red ping -c 3 80.0.0.2\r\n");
+    val = system("ip netns exec red ping -c 3 80.0.0.2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ip netns exec red ping -c 3 80::2\r\n");
+    val = system("ip netns exec red ping -c 3 80::2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    sleep(5);
+    cps_api_return_code_t rc = cps_api_ret_code_OK, rc_check = cps_api_ret_code_OK;
+    if (!ping_should_work) {
+        rc_check = cps_api_ret_code_ERR;
+    }
+    rc = nas_ut_validate_neigh_cfg(nh_vrf_name, AF_INET, "20.0.0.2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_validate_neigh_cfg(nh_vrf_name, AF_INET6, "20::2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    if (leak_neigh_should_present == false) {
+        rc_check = cps_api_ret_code_ERR;
+    }
+    rc = nas_ut_validate_neigh_cfg("blue", AF_INET, "20.0.0.2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("red", AF_INET, "20.0.0.2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("blue", AF_INET6, "20::2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("red", AF_INET6, "20::2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+
+    cps_api_return_code_t nht_rc = cps_api_ret_code_OK;
+    rc = nas_rt_nht_validate(nh_vrf_name, "20.0.0.2", 2, true);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate(nh_vrf_name, "20::2", 10, true);
+    ASSERT_TRUE(rc == nht_rc);
+
+    rc = nas_rt_nht_validate("blue", "20.0.0.2", 2, leak_neigh_should_present);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("blue", "20::2", 10, leak_neigh_should_present);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("red", "20.0.0.2", 2, leak_neigh_should_present);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("red", "20::2", 10, leak_neigh_should_present);
+    ASSERT_TRUE(rc == nht_rc);
+
+    rc = nas_rt_nht_validate("blue", "80.0.0.2", 2, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("blue", "80::2", 10, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("red", "80.0.0.2", 2, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("red", "80::2", 10, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+}
+
+static void nas_rt_ping_from_leak_vrfs_via_green_vrf(bool ping_should_work, const char *nh_vrf_name, bool clean_up = false) {
+    if (ping_should_work) {
+        printf("\r\nVerify that ping to [20.0.0.2 and 20::2] (leaked n/w) from blue, red and default VRF via green VRF working\r\n");
+    } else {
+        printf("\r\nVerify that ping to [20.0.0.2 and 20::2] (leaked n/w) from blue, red and default VRF via green VRF NOT working\r\n");
+    }
+    printf("ip netns exec blue ping -c 3 20.0.0.2\r\n");
+    int val = system("ip netns exec blue ping -c 3 20.0.0.2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+    printf("ip netns exec blue ping -c 3 20::2\r\n");
+    val = system("ip netns exec blue ping -c 3 20::2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ip netns exec red ping -c 3 20.0.0.2\r\n");
+    val = system("ip netns exec red ping -c 3 20.0.0.2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ip netns exec red ping -c 3 20::2\r\n");
+    val = system("ip netns exec red ping -c 3 20::2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ping -c 3 20.0.0.2\r\n");
+    val = system("ping -c 3 20.0.0.2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+
+    printf("ping -c 3 20::2\r\n");
+    val = system("ping -c 3 20::2");
+    if (ping_should_work && (val !=0)) {
+        ASSERT_TRUE(0);
+    } else if (!ping_should_work && (val == 0)) {
+        ASSERT_TRUE(0);
+    }
+    cps_api_return_code_t rc = cps_api_ret_code_OK, rc_check = cps_api_ret_code_OK;
+    if (!ping_should_work) {
+        rc_check = cps_api_ret_code_ERR;
+    }
+    sleep(5);
+    rc = nas_ut_validate_neigh_cfg("blue", AF_INET, "20.0.0.2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("red", AF_INET, "20.0.0.2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("blue", AF_INET6, "20::2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("red", AF_INET6, "20::2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg(nh_vrf_name, AF_INET, "20.0.0.2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg(nh_vrf_name, AF_INET6, "20::2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+
+    rc = nas_ut_validate_neigh_cfg("default", AF_INET, "20.0.0.2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    rc = nas_ut_validate_neigh_cfg("default", AF_INET6, "20::2", 2, ping_should_work, nh_vrf_name);
+    ASSERT_TRUE(rc == rc_check);
+    cps_api_return_code_t nht_rc = cps_api_ret_code_OK;
+
+    if (clean_up) {
+        nht_rc = cps_api_ret_code_ERR;
+    }
+    rc = nas_rt_nht_validate(nh_vrf_name, "20.0.0.2", 2, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate(nh_vrf_name, "20::2", 10, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("blue", "20.0.0.2", 2, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("blue", "20::2", 10, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("red", "20.0.0.2", 2, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("red", "20::2", 10, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("default", "20.0.0.2", 2, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+    rc = nas_rt_nht_validate("default", "20::2", 10, ping_should_work);
+    ASSERT_TRUE(rc == nht_rc);
+}
+
+TEST(nas_rt_vrf_test, nas_rt_leak_intf_route_default_to_non_default_vrf) {
+    cps_api_return_code_t rc;
+    int ret = system("opx-show-version | grep \"OS_NAME.*Enterprise\"");
+    if (ret != 0) {
+        return;
+    }
+    FILE *fp;
+    uint8_t iter = 2;
+
+    while (iter--) {
+
+        fp = fopen("/tmp/test_pre_req","w");
+        fprintf(fp, "configure terminal\n");
+        fprintf(fp, "ip vrf blue\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "ip vrf red\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "ip vrf green\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "interface loopback 0\n");
+        fprintf(fp, "no shutdown\n");
+        fprintf(fp, "ip vrf forwarding blue\n");
+        fprintf(fp, "ip address 50.0.0.1/32\n");
+        fprintf(fp, "ipv6 address 50::1/128\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "interface loopback 1\n");
+        fprintf(fp, "no shutdown\n");
+        fprintf(fp, "ip vrf forwarding red\n");
+        fprintf(fp, "ip address 60.0.0.1/32\n");
+        fprintf(fp, "ipv6 address 60::1/128\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "interface loopback 3\n");
+        fprintf(fp, "no shutdown\n");
+        fprintf(fp, "ip vrf forwarding green\n");
+        fprintf(fp, "ip address 70.0.0.1/32\n");
+        fprintf(fp, "ipv6 address 70::1/128\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+        fprintf(fp, "no switchport\n");
+        fprintf(fp, "ip address 20.0.0.1/16\n");
+        fprintf(fp, "ipv6 address 20::1/64\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "ip route 80.0.0.0/16 20.0.0.2\n");
+        fprintf(fp, "ipv6 route 80::/64 20::2\n");
+        fprintf(fp, "end\n");
+        fflush(fp);
+        system("sudo -u admin clish --b /tmp/test_pre_req");
+        fclose(fp);
+
+        printf("\r\n Step1 - Verify ping to 20.0.0.2 from default VRF\r\n");
+        system("ping -c 3 20.0.0.2");
+
+        sleep(2);
+        rc = nas_ut_validate_neigh_cfg("default", AF_INET, "20.0.0.2", 2, true, "default");
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+        nas_rt_nht_config("default", "20.0.0.2", 2, 1);
+        nas_rt_nht_config("default", "20::2", 10, 1);
+        nas_rt_nht_config("blue", "20.0.0.2", 2, 1);
+        nas_rt_nht_config("blue", "20::2", 10, 1);
+        nas_rt_nht_config("red", "20.0.0.2", 2, 1);
+        nas_rt_nht_config("red", "20::2", 10, 1);
+        nas_rt_nht_config("blue", "80.0.0.2", 2, 1);
+        nas_rt_nht_config("blue", "80::2", 10, 1);
+        nas_rt_nht_config("red", "80.0.0.2", 2, 1);
+        nas_rt_nht_config("red", "80::2", 10, 1);
+        nas_vrf_src_ip_config(1, "blue", 2, "50.0.0.1");
+        nas_vrf_src_ip_config(1, "blue", 10, "50::1");
+        printf("\r\nLeak the route 20.0.0.0/16 and 20::/64 from default VRF to blue and red VRFs\r\n");
+        nas_ut_rt_cfg ("blue",1, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("blue",1, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",1, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",1, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+
+        printf("\r\nLeak the route 80.0.0.0/16 and 80::/64 to reach via nexthop IP\r\n");
+        nas_ut_rt_cfg ("blue",1, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("blue",1, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",1, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",1, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+
+        nas_ut_rt_cfg ("blue",1, "0.0.0.0", 0, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("blue",1, "::", 0, AF_INET6, "default", "20::2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",1, "0.0.0.0", 0, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",1, "0::", 0, AF_INET6, "default", "20::2", b2b_leak_intf1);
+
+        printf("Leak the route 50.0.0.1/32 50::1/128 from blue VRF to default VRF for return path reachability\r\n");
+        nas_ut_rt_cfg ("default",1, "50.0.0.1", 32, AF_INET, "blue", NULL, "v-lo0");
+        nas_ut_rt_cfg ("default",1, "50::1", 128, AF_INET6, "blue", NULL, "v-lo0");
+
+        printf("Leak the route 60.0.0.1/32 60::1/128 from blue VRF to default VRF for return path reachability\r\n");
+        nas_ut_rt_cfg ("default",1, "60.0.0.1", 32, AF_INET, "red", NULL, "v-lo1");
+        nas_ut_rt_cfg ("default",1, "60::1", 128, AF_INET6, "red", NULL, "v-lo1");
+        nas_vrf_src_ip_config(1, "red", 2, "60.0.0.1");
+        nas_vrf_src_ip_config(1, "red", 10, "60::1");
+        nas_vrf_src_ip_config(1, "green", 2, "70.0.0.1");
+        nas_vrf_src_ip_config(1, "green", 10, "70::1");
+
+        printf("\r\n Verify that ping is not affected after configuring the default route \r\n");
+
+        sleep(5);
+        nas_rt_validate_leak_from_default_vrf_parent_conn_rt(true);
+        nas_rt_validate_leak_from_default_vrf_parent_reg_rt(true);
+        nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(true);
+        nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(true);
+        nas_rt_validate_leak_from_default_vrf_leaked_rt_loopbk_intf (true);
+        rc = nas_ut_validate_rt_cfg ("blue", AF_INET, "0.0.0.0", 0, "default", "20.0.0.2", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "::", 0, "default", "20::2", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_validate_rt_cfg ("red", AF_INET, "0.0.0.0", 0, "default", "20.0.0.2", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "::", 0, "default", "20::2", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+        nas_rt_ping_from_leak_vrfs_via_default_vrf(true, "default");
+
+        nas_ut_rt_cfg ("blue",0, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("blue",0, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",0, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",0, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+
+        nas_ut_rt_cfg ("blue",0, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("blue",0, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",0, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",0, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+        printf("\r\nVerify that the ping is working with default route after deleting the exact route\r\n");
+        nas_rt_ping_from_leak_vrfs_via_default_vrf_ext(true, "default", false);
+        sleep(5);
+        nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(false);
+        nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(false);
+
+        nas_ut_rt_cfg ("blue",0, "0.0.0.0", 0, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("blue",0, "::", 0, AF_INET6, "default", "20::2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",0, "0.0.0.0", 0, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",0, "0::", 0, AF_INET6, "default", "20::2", b2b_leak_intf1);
+        sleep(2);
+        rc = nas_ut_validate_rt_cfg ("blue", AF_INET, "0.0.0.0", 0, "default", "20.0.0.2", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+        rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "::", 0, "default", "20::2", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+        rc = nas_ut_validate_rt_cfg ("red", AF_INET, "0.0.0.0", 0, "default", "20.0.0.2", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+        rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "::", 0, "default", "20::2", "", true);
+        ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+        printf("\r\n Verify that the ping is NOT working since default route is deleted!\r\n");
+        nas_rt_ping_from_leak_vrfs_via_default_vrf_ext(false, "default", false);
+
+        nas_ut_rt_cfg ("blue",1, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("blue",1, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",1, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",1, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("blue",1, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("blue",1, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",1, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",1, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+
+        printf("\r\n Verify that the ping is working with exact route instead of default route \r\n");
+        sleep(5);
+        nas_rt_ping_from_leak_vrfs_via_default_vrf(true, "default");
+        nas_rt_validate_leak_from_default_vrf_parent_conn_rt(true);
+        nas_rt_validate_leak_from_default_vrf_parent_reg_rt(true);
+        nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(true);
+        nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(true);
+        nas_rt_validate_leak_from_default_vrf_leaked_rt_loopbk_intf (true);
+
+        if (iter != 0) {
+            printf("Step 2 - Clear the neighbors in the parent VRF and check the ping from leaked VRFs\r\n");
+            system("ip neigh del 20.0.0.2 dev e101-001-0");
+            system("ip neigh del 20::2 dev e101-001-0");
+            nas_rt_ping_from_leak_vrfs_via_default_vrf(true, "default");
+
+            nas_vrf_neigh_flush("blue", AF_INET, NULL);
+            nas_vrf_neigh_flush("blue", AF_INET6, NULL);
+            nas_vrf_neigh_flush("red", AF_INET, b2b_leak_intf1);
+            nas_vrf_neigh_flush("red", AF_INET6, b2b_leak_intf1);
+            nas_rt_ping_from_leak_vrfs_via_default_vrf(true, "default");
+            rc = nas_ut_validate_neigh_cfg("blue", AF_INET, "20.0.0.2", 2, true, "default");
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+            rc = nas_ut_validate_neigh_cfg("red", AF_INET, "20.0.0.2", 2, true, "default");
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+            rc = nas_ut_validate_neigh_cfg("blue", AF_INET6, "20::2", 2, true, "default");
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+            rc = nas_ut_validate_neigh_cfg("red", AF_INET6, "20::2", 2, true, "default");
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+            printf("Step 3 - Bring down the out interface in the parent VRF and check that ping is not working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "shutdown\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            nas_rt_ping_from_leak_vrfs_via_default_vrf(false, "default");
+            nas_rt_validate_leak_from_default_vrf_parent_conn_rt(false);
+            nas_rt_validate_leak_from_default_vrf_parent_reg_rt(false);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(false);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(false);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_loopbk_intf (true);
+            printf("Step 4 - Bring up the out interface in the parent VRF and check that ping is working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "no shutdown\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+
+            printf("Step 3a Add the IP address on out interface in the parent VRF and check that ping is working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "ip address 20.0.0.1/16\n");
+            fprintf(fp, "ipv6 address 20::1/64\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            sleep(5);
+            nas_rt_validate_leak_from_default_vrf_parent_conn_rt(true);
+            nas_rt_validate_leak_from_default_vrf_parent_reg_rt(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(false);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(false);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_loopbk_intf (true);
+            printf("\r\nLeak the route 20.0.0.0/16 and 20::/64 from default VRF to blue and red VRFs\r\n");
+            nas_ut_rt_cfg ("blue",1, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+            nas_ut_rt_cfg ("blue",1, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+            nas_ut_rt_cfg ("red",1, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+            nas_ut_rt_cfg ("red",1, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+            nas_ut_rt_cfg ("default",1, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+            nas_ut_rt_cfg ("default",1, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+            nas_ut_rt_cfg ("blue",1, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+            nas_ut_rt_cfg ("blue",1, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+            nas_ut_rt_cfg ("red",1, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+            nas_ut_rt_cfg ("red",1, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+            nas_rt_ping_from_leak_vrfs_via_default_vrf(true, "default");
+            nas_rt_validate_leak_from_default_vrf_parent_conn_rt(true);
+            nas_rt_validate_leak_from_default_vrf_parent_reg_rt(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_loopbk_intf (true);
+
+            printf("Step 5 - Remove the IP address from out interface in the parent VRF and check that ping is not working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "no ip address\n");
+            fprintf(fp, "no ipv6 address\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            /* @@TODO After IP address removal due to pro-active resolution, ARP is getting resolved even though
+             * the connected route is not present, remove the last arg, once this issue is fixed. */
+            //nas_rt_ping_from_leak_vrfs_via_default_vrf(false, "default", false, false);
+            nas_rt_validate_leak_from_default_vrf_parent_conn_rt(false);
+            nas_rt_validate_leak_from_default_vrf_parent_reg_rt(false);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_loopbk_intf (true);
+
+            printf("Step 6 - Add the IP address on out interface in the parent VRF and check that ping is working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "ip address 20.0.0.1/16\n");
+            fprintf(fp, "ipv6 address 20::1/64\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            nas_rt_ping_from_leak_vrfs_via_default_vrf(true, "default");
+            nas_rt_validate_leak_from_default_vrf_parent_conn_rt(true);
+            nas_rt_validate_leak_from_default_vrf_parent_reg_rt(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_loopbk_intf (true);
+
+            printf("Step 7 - Remove the IP address again from out interface in the parent VRF and check that ping is not working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "no ip address\n");
+            fprintf(fp, "no ipv6 address\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            //nas_rt_ping_from_leak_vrfs_via_default_vrf(false, "default", false, false);
+
+            nas_ut_rt_cfg ("blue",0, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+            nas_ut_rt_cfg ("blue",0, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+            nas_ut_rt_cfg ("red",0, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+            nas_ut_rt_cfg ("red",0, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+            sleep(5);
+            nas_rt_validate_leak_from_default_vrf_parent_conn_rt(false);
+            nas_rt_validate_leak_from_default_vrf_parent_reg_rt(false);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(false);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_loopbk_intf (true);
+
+            printf("\r\nLeak the route 20.0.0.0/16 and 20::/64 from default VRF to blue and red VRFs\r\n");
+            nas_ut_rt_cfg ("blue",1, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+            nas_ut_rt_cfg ("blue",1, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+            nas_ut_rt_cfg ("red",1, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+            nas_ut_rt_cfg ("red",1, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+            nas_ut_rt_cfg ("default",1, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+            nas_ut_rt_cfg ("default",1, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+            nas_ut_rt_cfg ("blue",1, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+            nas_ut_rt_cfg ("blue",1, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+            nas_ut_rt_cfg ("red",1, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+            nas_ut_rt_cfg ("red",1, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+
+            printf("Step 8 - Add the IP address on out interface in the parent VRF and check that ping is working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "ip address 20.0.0.1/16\n");
+            fprintf(fp, "ipv6 address 20::1/64\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            nas_rt_ping_from_leak_vrfs_via_default_vrf(true, "default");
+            nas_rt_validate_leak_from_default_vrf_parent_conn_rt(true);
+            nas_rt_validate_leak_from_default_vrf_parent_reg_rt(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(true);
+            nas_rt_validate_leak_from_default_vrf_leaked_rt_loopbk_intf (true);
+        }
+        nas_vrf_src_ip_config(0, "blue", 2, "50.0.0.1");
+        nas_vrf_src_ip_config(0, "blue", 10, "50::1");
+        nas_vrf_src_ip_config(0, "red", 2, "60.0.0.1");
+        nas_vrf_src_ip_config(0, "red", 10, "60::1");
+        nas_vrf_src_ip_config(0, "green", 2, "70.0.0.1");
+        nas_vrf_src_ip_config(0, "green", 10, "70::1");
+        printf("\r\n Remove the route 20.0.0.0/16 and 20::/64 from default VRF to blue and red VRFs\r\n");
+        nas_ut_rt_cfg ("blue",0, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("blue",0, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",0, "20.0.0.0", 16, AF_INET, "default", NULL, b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",0, "20::", 64, AF_INET6, "default", NULL, b2b_leak_intf1);
+
+        printf("Remove the route 50.0.0.1/32 50::1/128 from blue VRF to default VRF for return path reachability\r\n");
+        nas_ut_rt_cfg ("default",0, "50.0.0.1", 32, AF_INET, "blue", NULL, "v-lo0");
+        nas_ut_rt_cfg ("default",0, "50::1", 128, AF_INET6, "blue", NULL, "v-lo0");
+
+        printf("Remove the route 60.0.0.1/32 60::1/128 from blue VRF to default VRF for return path reachability\r\n");
+        nas_ut_rt_cfg ("default",0, "60.0.0.1", 32, AF_INET, "red", NULL, "v-lo1");
+        nas_ut_rt_cfg ("default",0, "60::1", 128, AF_INET6, "red", NULL, "v-lo1");
+
+        nas_ut_rt_cfg ("blue",0, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("blue",0, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",0, "80.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+        nas_ut_rt_cfg ("red",0, "80::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+
+        nas_rt_nht_config("default", "20.0.0.2", 2, 0);
+        nas_rt_nht_config("default", "20::2", 10, 0);
+        nas_rt_nht_config("blue", "20.0.0.2", 2, 0);
+        nas_rt_nht_config("blue", "20::2", 10, 0);
+        nas_rt_nht_config("red", "20.0.0.2", 2, 0);
+        nas_rt_nht_config("red", "20::2", 10, 0);
+        nas_rt_nht_config("blue", "80.0.0.2", 2, 0);
+        nas_rt_nht_config("blue", "80::2", 10, 0);
+        nas_rt_nht_config("red", "80.0.0.2", 2, 0);
+        nas_rt_nht_config("red", "80::2", 10, 0);
+        fp = fopen("/tmp/test_pre_req","w");
+        fprintf(fp, "configure terminal\n");
+        fprintf(fp, "interface loopback 0\n");
+        fprintf(fp, "no ip address 50.0.0.1/32\n");
+        fprintf(fp, "no ipv6 address 50::1/128\n");
+        fprintf(fp, "no ip vrf forwarding\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "no interface loopback 0\n");
+        fprintf(fp, "interface loopback 1\n");
+        fprintf(fp, "no ip address 60.0.0.1/32\n");
+        fprintf(fp, "no ipv6 address 60::1/128\n");
+        fprintf(fp, "no ip vrf forwarding\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "no interface loopback 1\n");
+        fprintf(fp, "interface loopback 3\n");
+        fprintf(fp, "no ip address 70.0.0.1/32\n");
+        fprintf(fp, "no ipv6 address 70::1/128\n");
+        fprintf(fp, "no ip vrf forwarding\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "no interface loopback 3\n");
+        fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+        fprintf(fp, "no ip address 20.0.0.1/16\n");
+        fprintf(fp, "no ipv6 address 20::1/64\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "no ip vrf blue\n");
+        fprintf(fp, "no ip vrf red\n");
+        fprintf(fp, "no ip vrf green\n");
+        fprintf(fp, "end\n");
+        fflush(fp);
+        system("sudo -u admin clish --b /tmp/test_pre_req");
+        fclose(fp);
+
+        nas_rt_ping_from_leak_vrfs_via_default_vrf(false, "default", true);
+        nas_rt_validate_leak_from_default_vrf_parent_conn_rt(false);
+        nas_rt_validate_leak_from_default_vrf_parent_reg_rt(false);
+        nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_ip(false);
+        nas_rt_validate_leak_from_default_vrf_leaked_rt_nh_intf(false);
+        nas_rt_validate_leak_from_default_vrf_leaked_rt_loopbk_intf (false);
+        printf("\r\n ******************Iteration %d completed**********************", iter);
+    }
+}
+
+TEST(nas_rt_vrf_test, nas_rt_leak_intf_route_non_default_to_non_default_vrf) {
+    printf("\r\n Clear the neighbors in the peer node since with VRF, the MAC is changed, "
+           "already learnt nbr should be cleared in the peer\r\n");
+    cps_api_return_code_t rc;
+    int ret = system("opx-show-version | grep \"OS_NAME.*Enterprise\"");
+    if (ret != 0) {
+        return;
+    }
+    FILE *fp;
+    uint8_t iter = 2;
+
+    while (iter--) {
+        fp = fopen("/tmp/test_pre_req","w");
+        fprintf(fp, "configure terminal\n");
+        fprintf(fp, "ip vrf blue\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "ip vrf red\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "ip vrf green\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "interface loopback 0\n");
+        fprintf(fp, "no shutdown\n");
+        fprintf(fp, "ip vrf forwarding blue\n");
+        fprintf(fp, "ip address 50.0.0.1/32\n");
+        fprintf(fp, "ipv6 address 50::1/128\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "interface loopback 1\n");
+        fprintf(fp, "no shutdown\n");
+        fprintf(fp, "ip vrf forwarding red\n");
+        fprintf(fp, "ip address 60.0.0.1/32\n");
+        fprintf(fp, "ipv6 address 60::1/128\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "interface loopback 2\n");
+        fprintf(fp, "no shutdown\n");
+        fprintf(fp, "ip address 70.0.0.1/32\n");
+        fprintf(fp, "ipv6 address 70::1/128\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+        fprintf(fp, "no switchport\n");
+        fprintf(fp, "ip vrf forwarding green\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "end\n");
+        fflush(fp);
+        system("sudo -u admin clish --b /tmp/test_pre_req");
+        fclose(fp);
+
+        nas_rt_nht_config("green", "20.0.0.2", 2, 1);
+        nas_rt_nht_config("green", "20::2", 10, 1);
+        nas_rt_nht_config("blue", "20.0.0.2", 2, 1);
+        nas_rt_nht_config("blue", "20::2", 10, 1);
+        nas_rt_nht_config("red", "20.0.0.2", 2, 1);
+        nas_rt_nht_config("red", "20::2", 10, 1);
+        nas_rt_nht_config("default", "20.0.0.2", 2, 1);
+        nas_rt_nht_config("default", "20::2", 10, 1);
+        printf("\r\nLeak the route 20.0.0.0/16 and 20::/64 from green VRF to blue and red VRFs\r\n");
+        nas_ut_rt_cfg ("blue",1, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+        nas_ut_rt_cfg ("blue",1, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+        nas_ut_rt_cfg ("red",1, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+        nas_ut_rt_cfg ("red",1, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+        nas_ut_rt_cfg ("default",1, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+        nas_ut_rt_cfg ("default",1, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+
+        printf("Leak the route 50.0.0.1/32 50::1/128 from blue VRF to green VRF for return path reachability\r\n");
+        nas_ut_rt_cfg ("green",1, "50.0.0.1", 32, AF_INET, "blue", NULL, "v-lo0");
+        nas_ut_rt_cfg ("green",1, "50::1", 128, AF_INET6, "blue", NULL, "v-lo0");
+
+        printf("Leak the route 60.0.0.1/32 60::1/128 from blue VRF to green VRF for return path reachability\r\n");
+        nas_ut_rt_cfg ("green",1, "60.0.0.1", 32, AF_INET, "red", NULL, "v-lo1");
+        nas_ut_rt_cfg ("green",1, "60::1", 128, AF_INET6, "red", NULL, "v-lo1");
+
+        printf("Leak the route 70.0.0.1/32 70::1/128 from blue VRF to green VRF for return path reachability\r\n");
+        nas_ut_rt_cfg ("green",1, "70.0.0.1", 32, AF_INET, "default", NULL, "lo2");
+        nas_ut_rt_cfg ("green",1, "70::1", 128, AF_INET6, "default", NULL, "lo2");
+        nas_vrf_src_ip_config(1, "blue", 2, "50.0.0.1");
+        nas_vrf_src_ip_config(1, "blue", 10, "50::1");
+        nas_vrf_src_ip_config(1, "red", 2, "60.0.0.1");
+        nas_vrf_src_ip_config(1, "red", 10, "60::1");
+        nas_vrf_src_ip_config(1, "default", 2, "70.0.0.1");
+        nas_vrf_src_ip_config(1, "default", 10, "70::1");
+
+
+        fp = fopen("/tmp/test_pre_req","w");
+        fprintf(fp, "configure terminal\n");
+        fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+        fprintf(fp, "ip address 20.0.0.1/16\n");
+        fprintf(fp, "ipv6 address 20::1/64\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "end\n");
+        fflush(fp);
+        system("sudo -u admin clish --b /tmp/test_pre_req");
+        fclose(fp);
+        sleep(2);
+        printf("\r\n Step 1 - Verify ping to 20.0.0.2 from green VRF\r\n");
+        system("ip netns exec green ping -c 3 20.0.0.2");
+        sleep(2);
+        rc = nas_ut_validate_neigh_cfg("green", AF_INET, "20.0.0.2", 2, true, "green");
+        ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+
+        sleep(5);
+        nas_rt_validate_leak_route_from_green_vrf(cps_api_ret_code_OK, cps_api_ret_code_OK);
+        nas_rt_ping_from_leak_vrfs_via_green_vrf(true, "green");
+
+        if (iter != 0) {
+            printf("Step 2 - Clear the neighbors in the parent VRF and check the ping from leaked VRFs\r\n");
+            system("ip netns exec green ip neigh del 20.0.0.2 dev v-e101-001-0");
+            system("ip netns exec green ip neigh del 20::2 dev v-e101-001-0");
+            nas_rt_ping_from_leak_vrfs_via_green_vrf(true, "green");
+
+            nas_vrf_neigh_flush("blue", AF_INET, NULL);
+            nas_vrf_neigh_flush("blue", AF_INET6, NULL);
+            nas_vrf_neigh_flush("red", AF_INET, b2b_leak_vrf_intf1);
+            nas_vrf_neigh_flush("red", AF_INET6, b2b_leak_vrf_intf1);
+            nas_vrf_neigh_flush("default", AF_INET, b2b_leak_vrf_intf1);
+            nas_vrf_neigh_flush("default", AF_INET6, b2b_leak_vrf_intf1);
+            sleep(2);
+            rc = nas_ut_validate_neigh_cfg("blue", AF_INET, "20.0.0.2", 2, true, "green");
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+            rc = nas_ut_validate_neigh_cfg("red", AF_INET, "20.0.0.2", 2, true, "green");
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+            rc = nas_ut_validate_neigh_cfg("default", AF_INET, "20.0.0.2", 2, true, "green");
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+            rc = nas_ut_validate_neigh_cfg("blue", AF_INET6, "20::2", 2, true, "green");
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+            rc = nas_ut_validate_neigh_cfg("red", AF_INET6, "20::2", 2, true, "green");
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+            rc = nas_ut_validate_neigh_cfg("default", AF_INET6, "20::2", 2, true, "green");
+            ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+            printf("Step 3 - Bring down the out interface in the parent VRF and check that ping is not working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "shutdown\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            sleep(5);
+            nas_rt_ping_from_leak_vrfs_via_green_vrf(false, "green");
+
+            printf("Step 4 - Bring up the out interface in the parent VRF and check that ping is working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "no shutdown\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            sleep(2);
+            printf("\r\nLeak the route 20.0.0.0/16 and 20::/64 from green VRF to blue and red VRFs\r\n");
+            nas_ut_rt_cfg ("blue",1, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("blue",1, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("red",1, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("red",1, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("default",1, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("default",1, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+            sleep(5);
+            nas_rt_ping_from_leak_vrfs_via_green_vrf(true, "green");
+
+            printf("Step 5 - Remove the IP address from out interface in the parent VRF and check that ping is not working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "no ip address\n");
+            fprintf(fp, "no ipv6 address\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            sleep(5);
+            nas_rt_ping_from_leak_vrfs_via_green_vrf(false, "green");
+            nas_rt_validate_leak_route_from_green_vrf(cps_api_ret_code_OK, cps_api_ret_code_ERR);
+
+            printf("Step 6 - Add the IP address on out interface in the parent VRF and check that ping is working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "ip address 20.0.0.1/16\n");
+            fprintf(fp, "ipv6 address 20::1/64\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            sleep(5);
+            nas_rt_ping_from_leak_vrfs_via_green_vrf(true, "green");
+
+            printf("Step 7 - Remove the IP address again from out interface in the parent VRF and check that ping is not working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "no ip address\n");
+            fprintf(fp, "no ipv6 address\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            sleep(5);
+            nas_rt_ping_from_leak_vrfs_via_green_vrf(false, "green");
+            nas_rt_validate_leak_route_from_green_vrf(cps_api_ret_code_OK, cps_api_ret_code_ERR);
+
+            printf("\r\nLeak the route 20.0.0.0/16 and 20::/64 from green VRF to blue and red VRFs\r\n");
+            nas_ut_rt_cfg ("blue",0, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("blue",0, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("red",0, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("red",0, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("default",0, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("default",0, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+            sleep(5);
+            rc = nas_ut_validate_rt_cfg ("blue", AF_INET, "20.0.0.0", 16, "green", "", "", true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+            rc = nas_ut_validate_rt_cfg ("blue", AF_INET6, "20::", 64, "green", "", "", true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+
+            rc = nas_ut_validate_rt_cfg ("red", AF_INET, "20.0.0.0", 16, "green", "", "", true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+            rc = nas_ut_validate_rt_cfg ("red", AF_INET6, "20::", 64, "green", "", "", true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+
+            rc = nas_ut_validate_rt_cfg ("default", AF_INET, "20.0.0.0", 16, "green", "", "", true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+            rc = nas_ut_validate_rt_cfg ("default", AF_INET6, "20::", 64, "green", "", "", true);
+            ASSERT_TRUE(rc == cps_api_ret_code_ERR);
+
+            printf("\r\nLeak the route 20.0.0.0/16 and 20::/64 from green VRF to blue and red VRFs\r\n");
+            nas_ut_rt_cfg ("blue",1, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("blue",1, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("red",1, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("red",1, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("default",1, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+            nas_ut_rt_cfg ("default",1, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+            sleep(5);
+            nas_rt_validate_leak_route_from_green_vrf(cps_api_ret_code_OK, cps_api_ret_code_ERR);
+
+            printf("Step 8 - Add the IP address on out interface in the parent VRF and check that ping is working from leaked VRFs\r\n");
+            fp = fopen("/tmp/test_pre_req","w");
+            fprintf(fp, "configure terminal\n");
+            fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+            fprintf(fp, "ip address 20.0.0.1/16\n");
+            fprintf(fp, "ipv6 address 20::1/64\n");
+            fprintf(fp, "end\n");
+            fflush(fp);
+            system("sudo -u admin clish --b /tmp/test_pre_req");
+            fclose(fp);
+            sleep(5);
+            nas_rt_ping_from_leak_vrfs_via_green_vrf(true, "green");
+        }
+        nas_vrf_src_ip_config(0, "blue", 2, "50.0.0.1");
+        nas_vrf_src_ip_config(0, "blue", 10, "50::1");
+        nas_vrf_src_ip_config(0, "red", 2, "60.0.0.1");
+        nas_vrf_src_ip_config(0, "red", 10, "60::1");
+        nas_vrf_src_ip_config(0, "default", 2, "70.0.0.1");
+        nas_vrf_src_ip_config(0, "default", 10, "70::1");
+        printf("\r\n Remove the route 20.0.0.0/16 and 20::/64 from green VRF to blue and red VRFs\r\n");
+        nas_ut_rt_cfg ("blue",0, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+        nas_ut_rt_cfg ("blue",0, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+        nas_ut_rt_cfg ("red",0, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+        nas_ut_rt_cfg ("red",0, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+        nas_ut_rt_cfg ("default",0, "20.0.0.0", 16, AF_INET, "green", NULL, b2b_leak_vrf_intf1);
+        nas_ut_rt_cfg ("default",0, "20::", 64, AF_INET6, "green", NULL, b2b_leak_vrf_intf1);
+
+        printf("Remove the route 50.0.0.1/32 50::1/128 from blue VRF to green VRF for return path reachability\r\n");
+        nas_ut_rt_cfg ("green",0, "50.0.0.1", 32, AF_INET, "blue", NULL, "v-lo0");
+        nas_ut_rt_cfg ("green",0, "50::1", 128, AF_INET6, "blue", NULL, "v-lo0");
+
+        printf("Remove the route 60.0.0.1/32 60::1/128 from blue VRF to green VRF for return path reachability\r\n");
+        nas_ut_rt_cfg ("green",0, "60.0.0.1", 32, AF_INET, "red", NULL, "v-lo1");
+        nas_ut_rt_cfg ("green",0, "60::1", 128, AF_INET6, "red", NULL, "v-lo1");
+
+        printf("Remove the route 70.0.0.1/32 70::1/128 from default VRF to green VRF for return path reachability\r\n");
+        nas_ut_rt_cfg ("green",0, "70.0.0.1", 32, AF_INET, "default", NULL, "lo2");
+        nas_ut_rt_cfg ("green",0, "70::1", 128, AF_INET6, "default", NULL, "lo2");
+
+        nas_rt_nht_config("green", "20.0.0.2", 2, 0);
+        nas_rt_nht_config("green", "20::2", 10, 0);
+        nas_rt_nht_config("blue", "20.0.0.2", 2, 0);
+        nas_rt_nht_config("blue", "20::2", 10, 0);
+        nas_rt_nht_config("red", "20.0.0.2", 2, 0);
+        nas_rt_nht_config("red", "20::2", 10, 0);
+        nas_rt_nht_config("default", "20.0.0.2", 2, 0);
+        nas_rt_nht_config("default", "20::2", 10, 0);
+        fp = fopen("/tmp/test_pre_req","w");
+        fprintf(fp, "configure terminal\n");
+        fprintf(fp, "interface loopback 0\n");
+        fprintf(fp, "no ip address 50.0.0.1/32\n");
+        fprintf(fp, "no ipv6 address 50::1/128\n");
+        fprintf(fp, "no ip vrf forwarding\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "no interface loopback 0\n");
+        fprintf(fp, "interface loopback 1\n");
+        fprintf(fp, "no ip address 60.0.0.1/32\n");
+        fprintf(fp, "no ipv6 address 60::1/128\n");
+        fprintf(fp, "no ip vrf forwarding\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "no interface loopback 1\n");
+        fprintf(fp, "interface loopback 2\n");
+        fprintf(fp, "no ip address 70.0.0.1/32\n");
+        fprintf(fp, "no ipv6 address 70::1/128\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "no interface loopback 2\n");
+        fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+        fprintf(fp, "no ip address 20.0.0.1/16\n");
+        fprintf(fp, "no ipv6 address 20::1/64\n");
+        fprintf(fp, "no ip vrf forwarding\n");
+        fprintf(fp, "exit\n");
+        fprintf(fp, "no ip vrf blue\n");
+        fprintf(fp, "no ip vrf red\n");
+        fprintf(fp, "no ip vrf green\n");
+        fprintf(fp, "end\n");
+        fflush(fp);
+        system("sudo -u admin clish --b /tmp/test_pre_req");
+        fclose(fp);
+        sleep(5);
+
+        nas_rt_validate_leak_route_from_green_vrf(cps_api_ret_code_ERR, cps_api_ret_code_ERR);
+        nas_rt_ping_from_leak_vrfs_via_green_vrf(false, "green", true);
+
+        printf("\r\n ******************Iteration %d completed**********************", iter);
+    }
+}
+
+TEST(nas_rt_vrf_test, nas_rt_leak_nh_route_default_to_blue) {
+    int ret = system("opx-show-version | grep \"OS_NAME.*Enterprise\"");
+    if (ret != 0) {
+        return;
+    }
+    FILE *fp;
+
+    fp = fopen("/tmp/test_pre_req","w");
+    fprintf(fp, "configure terminal\n");
+    fprintf(fp, "ip vrf blue\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "interface loopback 0\n");
+    fprintf(fp, "no shutdown\n");
+    fprintf(fp, "ip vrf forwarding blue\n");
+    fprintf(fp, "ip address 50.0.0.1/32\n");
+    fprintf(fp, "ipv6 address 50::1/128\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+    fprintf(fp, "no switchport\n");
+    fprintf(fp, "ip address 20.0.0.1/16\n");
+    fprintf(fp, "ipv6 address 20::1/64\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "ip route 60.0.0.0/8 20.0.0.2\n");
+    fprintf(fp, "ipv6 route 60::/64 20::2\n");
+    fprintf(fp, "end\n");
+    fflush(fp);
+    system("sudo -u admin clish --b /tmp/test_pre_req");
+    fclose(fp);
+
+    sleep(5);
+    printf("\r\n Verify ping to 20.0.0.2 from default VRF\r\n");
+    printf("\r\n ping -c 3 20.0.0.2\r\n");
+    system("ping -c 3 20.0.0.2");
+
+    printf("\r\n Leak the route 60.0.0.0/16 and 60::/64 from default VRF to blue VRF\r\n");
+    nas_ut_rt_cfg ("blue",1, "60.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+    nas_ut_rt_cfg ("blue",1, "60::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+    printf("\r\n Leak the route 50.0.0.0/16 50::/64 from blue VRF to default VRF for return path reachability\r\n");
+    nas_ut_rt_cfg ("default",1, "50.0.0.0", 16, AF_INET, "blue", NULL, "v-lo0");
+    nas_ut_rt_cfg ("default",1, "50::", 64, AF_INET6, "blue", NULL, "v-lo0");
+    sleep(5);
+
+    printf("\r\n Verify ping to [60.0.0.2 and 60::2] (leaked n/w) from blue VRF via default VRF\r\n");
+    system("ip netns exec blue ping -c 3 60.0.0.2 -I 50.0.0.1");
+    system("ip netns exec blue ping -c 3 60::2 -I 50::1");
+    system("ip neigh del 20.0.0.2 dev e101-001-0");
+    system("ip neigh del 20::2 dev e101-001-0");
+    printf("\r\n Verify ping again to [60.0.0.2 and 60::2] (leaked n/w) from blue VRF via default VRF after neighbor clear in default VRF\r\n");
+    system("ip netns exec blue ping -c 3 60.0.0.2 -I 50.0.0.1");
+    system("ip netns exec blue ping -c 3 60::2 -I 50::1");
+    sleep(2);
+    nas_ut_rt_cfg ("blue",0, "60.0.0.0", 16, AF_INET, "default", "20.0.0.2", b2b_leak_intf1);
+    nas_ut_rt_cfg ("blue",0, "60::", 64, AF_INET6, "default", "20::2", b2b_leak_intf1);
+    printf("\r\n Leak the route 50.0.0.0/16 50::/64 from blue VRF to default VRF for return path reachability\r\n");
+    nas_ut_rt_cfg ("default",0, "50.0.0.0", 16, AF_INET, "blue", NULL, "v-lo0");
+    nas_ut_rt_cfg ("default",0, "50::", 64, AF_INET6, "blue", NULL, "v-lo0");
+    printf("\r\nThe below ping expected to fail\r\n");
+    system("ip netns exec blue ping -c 1 20.0.0.2 -I 50.0.0.1");
+    system("ip netns exec blue ping -c 1 20::2 -I 50::1");
+
+    fp = fopen("/tmp/test_pre_req","w");
+    fprintf(fp, "configure terminal\n");
+    fprintf(fp, "interface loopback 0\n");
+    fprintf(fp, "no ip address 50.0.0.1/32\n");
+    fprintf(fp, "no ipv6 address 50::1/128\n");
+    fprintf(fp, "no ip vrf forwarding\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "no ip route 60.0.0.0/8 20.0.0.2\n");
+    fprintf(fp, "no ipv6 route 60::/64 20::2\n");
+    fprintf(fp, "no interface loopback 0\n");
+    sleep(2);
+    fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+    fprintf(fp, "no ip address 20.0.0.1/16\n");
+    fprintf(fp, "no ipv6 address 20::1/64\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "no ip vrf blue\n");
+    fprintf(fp, "end\n");
+    fflush(fp);
+    system("sudo -u admin clish --b /tmp/test_pre_req");
+    fclose(fp);
+}
+
+TEST(nas_rt_vrf_test, nas_rt_leak_intf_route_red_to_blue) {
+    int ret = system("opx-show-version | grep \"OS_NAME.*Enterprise\"");
+    if (ret != 0) {
+        return;
+    }
+    FILE *fp;
+
+    fp = fopen("/tmp/test_pre_req","w");
+    fprintf(fp, "configure terminal\n");
+    fprintf(fp, "ip vrf blue\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "ip vrf red\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "interface loopback 0\n");
+    fprintf(fp, "no shutdown\n");
+    fprintf(fp, "ip vrf forwarding blue\n");
+    fprintf(fp, "ip address 50.0.0.1/32\n");
+    fprintf(fp, "ipv6 address 50::1/128\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+    fprintf(fp, "no shutdown\n");
+    fprintf(fp, "no switchport\n");
+    fprintf(fp, "ip vrf forwarding red\n");
+    fprintf(fp, "ip address 20.0.0.1/16\n");
+    fprintf(fp, "ipv6 address 20::1/64\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "end\n");
+    fflush(fp);
+    system("sudo -u admin clish --b /tmp/test_pre_req");
+    fclose(fp);
+
+    sleep(2);
+    printf("\r\n Verify ping to 20.0.0.2 from red VRF\r\n");
+    system("ip netns exec red ping -c 3 20.0.0.2");
+
+    printf("\r\n Leak the route 20.0.0.0/16 and 20::/64 from red VRF to blue VRF\r\n");
+    nas_ut_rt_cfg ("blue",1, "20.0.0.0", 16, AF_INET, "red", NULL, b2b_leak_vrf_intf1);
+    nas_ut_rt_cfg ("blue",1, "20::", 64, AF_INET6, "red", NULL, b2b_leak_vrf_intf1);
+    printf("\r\n Leak the route 50.0.0.0/16 50::/64 from blue VRF to red VRF for return path reachability\r\n");
+    nas_ut_rt_cfg ("red",1, "50.0.0.0", 16, AF_INET, "blue", NULL, "v-lo0");
+    nas_ut_rt_cfg ("red",1, "50::", 64, AF_INET6, "blue", NULL, "v-lo0");
+    sleep(5);
+    printf("\r\n Verify ping to [20.0.0.2 and 20::2] (leaked n/w) from blue VRF via red VRF\r\n");
+    system("ip netns exec blue ping -c 3 20.0.0.2 -I 50.0.0.1");
+    system("ip netns exec blue ping -c 3 20::2 -I 50::1");
+
+    system("ip netns exec red ip neigh del 20.0.0.2 dev e101-001-0");
+    system("ip netns exec red ip neigh del 20::2 dev e101-001-0");
+    printf("\r\n Verify ping again to [20.0.0.2 and 20::2] (leaked n/w) from blue VRF via red VRF after neighbor clear in default VRF\r\n");
+    system("ip netns exec blue ping -c 3 20.0.0.2 -I 50.0.0.1");
+    system("ip netns exec blue ping -c 3 20::2 -I 50::1");
+    sleep(2);
+    nas_ut_rt_cfg ("blue",0, "20.0.0.0", 16, AF_INET, "red", NULL, b2b_leak_vrf_intf1);
+    nas_ut_rt_cfg ("blue",0, "20::", 64, AF_INET6, "red", NULL, b2b_leak_vrf_intf1);
+    nas_ut_rt_cfg ("red",0, "50.0.0.0", 16, AF_INET, "blue", NULL, "v-lo0");
+    nas_ut_rt_cfg ("red",0, "50::", 64, AF_INET6, "blue", NULL, "v-lo0");
+    printf("\r\nThe below ping expected to fail\r\n");
+    system("ip netns exec blue ping -c 1 20.0.0.2 -I 50.0.0.1");
+    system("ip netns exec blue ping -c 1 20::2 -I 50::1");
+
+    fp = fopen("/tmp/test_pre_req","w");
+    fprintf(fp, "configure terminal\n");
+    fprintf(fp, "interface loopback 0\n");
+    fprintf(fp, "no ip address 50.0.0.1/32\n");
+    fprintf(fp, "no ipv6 address 50::1/128\n");
+    fprintf(fp, "no ip vrf forwarding\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "no interface loopback 0\n");
+    fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+    fprintf(fp, "no ip address 20.0.0.1/16\n");
+    fprintf(fp, "no ipv6 address 20::1/64\n");
+    fprintf(fp, "no ip vrf forwarding\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "no ip vrf blue\n");
+    fprintf(fp, "no ip vrf red\n");
+    fprintf(fp, "end\n");
+    fflush(fp);
+    system("sudo -u admin clish --b /tmp/test_pre_req");
+    fclose(fp);
+
+}
+
+TEST(nas_rt_vrf_test, nas_rt_leak_nh_route_red_to_blue) {
+    int ret = system("opx-show-version | grep \"OS_NAME.*Enterprise\"");
+    if (ret != 0) {
+        return;
+    }
+    FILE *fp;
+
+    fp = fopen("/tmp/test_pre_req","w");
+    fprintf(fp, "configure terminal\n");
+    fprintf(fp, "ip vrf blue\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "interface loopback 0\n");
+    fprintf(fp, "no shutdown\n");
+    fprintf(fp, "ip vrf forwarding blue\n");
+    fprintf(fp, "ip address 50.0.0.1/32\n");
+    fprintf(fp, "ipv6 address 50::1/128\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+    fprintf(fp, "no switchport\n");
+    fprintf(fp, "ip address 20.0.0.1/16\n");
+    fprintf(fp, "ipv6 address 20::1/64\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "ip vrf blue ip route 60.0.0.0/8 20.0.0.2\n");
+    fprintf(fp, "ipv6 vrf blue ipv6 route 60::/64 20::2\n");
+    fprintf(fp, "end\n");
+    fflush(fp);
+    system("sudo -u admin clish --b /tmp/test_pre_req");
+    fclose(fp);
+
+    sleep(5);
+    printf("\r\n Verify ping to 20.0.0.2 from red VRF\r\n");
+    printf("\r\n ip netns exec red ping -c 3 20.0.0.2\r\n");
+    system("ip netns exec red ping -c 3 20.0.0.2");
+
+    printf("\r\n Leak the route 60.0.0.0/16 and 60::/64 from red VRF to blue VRF\r\n");
+    nas_ut_rt_cfg ("blue",1, "60.0.0.0", 16, AF_INET, "red", "20.0.0.2", b2b_leak_intf1);
+    nas_ut_rt_cfg ("blue",1, "60::", 64, AF_INET6, "red", "20::2", b2b_leak_intf1);
+    printf("\r\n Leak the route 50.0.0.0/16 50::/64 from blue VRF to red VRF for return path reachability\r\n");
+    nas_ut_rt_cfg ("red",1, "50.0.0.0", 16, AF_INET, "blue", NULL, "v-lo0");
+    nas_ut_rt_cfg ("red",1, "50::", 64, AF_INET6, "blue", NULL, "v-lo0");
+    sleep(5);
+
+    printf("\r\n Verify ping to [60.0.0.2 and 60::2] (leaked n/w) from blue VRF via red VRF\r\n");
+    system("ip netns exec blue ping -c 3 60.0.0.2 -I 50.0.0.1");
+    system("ip netns exec blue ping -c 3 60::2 -I 50::1");
+    system("ip netns exec blue ip neigh del 20.0.0.2 dev e101-001-0");
+    system("ip netns exec blue ip neigh del 20::2 dev e101-001-0");
+    printf("\r\n Verify ping again to [60.0.0.2 and 60::2] (leaked n/w) from blue VRF via red VRF after neighbor clear in default VRF\r\n");
+    system("ip netns exec red ping -c 3 60.0.0.2 -I 50.0.0.1");
+    system("ip netns exec red ping -c 3 60::2 -I 50::1");
+    sleep(2);
+    nas_ut_rt_cfg ("blue",0, "60.0.0.0", 16, AF_INET, "red", "20.0.0.2", b2b_leak_intf1);
+    nas_ut_rt_cfg ("blue",0, "60::", 64, AF_INET6, "red", "20::2", b2b_leak_intf1);
+    printf("\r\n Leak the route 50.0.0.0/16 50::/64 from blue VRF to red VRF for return path reachability\r\n");
+    nas_ut_rt_cfg ("red",0, "50.0.0.0", 16, AF_INET, "blue", NULL, "v-lo0");
+    nas_ut_rt_cfg ("red",0, "50::", 64, AF_INET6, "blue", NULL, "v-lo0");
+    printf("\r\nThe below ping expected to fail\r\n");
+    system("ip netns exec blue ping -c 1 20.0.0.2 -I 50.0.0.1");
+    system("ip netns exec blue ping -c 1 20::2 -I 50::1");
+
+    fp = fopen("/tmp/test_pre_req","w");
+    fprintf(fp, "configure terminal\n");
+    fprintf(fp, "interface loopback 0\n");
+    fprintf(fp, "no ip address 50.0.0.1/32\n");
+    fprintf(fp, "no ipv6 address 50::1/128\n");
+    fprintf(fp, "no ip vrf forwarding\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "no ip vrf blue ip route 60.0.0.0/8 20.0.0.2\n");
+    fprintf(fp, "no ipv6 vrf blue ipv6 route 60::/64 20::2\n");
+    fprintf(fp, "no interface loopback 0\n");
+    fprintf(fp, "interface ethernet %s\n", DoD_b2b_leak_intf1);
+    fprintf(fp, "no ip address 20.0.0.1/16\n");
+    fprintf(fp, "no ipv6 address 20::1/64\n");
+    fprintf(fp, "no ip vrf forwarding\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "no ip vrf blue\n");
+    fprintf(fp, "no ip vrf red\n");
+    fprintf(fp, "end\n");
+    fflush(fp);
+    system("sudo -u admin clish --b /tmp/test_pre_req");
+    fclose(fp);
+}
+
 TEST(nas_rt_vrf_test, nas_rt_leak_route) {
     cps_api_return_code_t rc;
     char cmd [512];
@@ -941,7 +2665,7 @@ TEST(nas_rt_vrf_test, nas_rt_scal_vrf) {
             ASSERT_TRUE(rc == cps_api_ret_code_ERR);
             rc = nas_ut_validate_rt_cfg (vrf, AF_INET, "100.0.0.0", 24, vrf, "", "", true);
             ASSERT_TRUE(rc == cps_api_ret_code_ERR);
-            rc = nas_ut_validate_neigh_cfg(vrf, AF_INET, "100.0.0.2", 128, true);
+            rc = nas_ut_validate_neigh_cfg(vrf, AF_INET, "100.0.0.2", 128, true, NULL);
             ASSERT_TRUE(rc == cps_api_ret_code_ERR);
             rc = nas_ut_validate_rt_cfg (vrf, AF_INET, "60.0.0.0", 8, vrf, "", "", true);
             ASSERT_TRUE(rc == cps_api_ret_code_ERR);
@@ -949,7 +2673,7 @@ TEST(nas_rt_vrf_test, nas_rt_scal_vrf) {
             ASSERT_TRUE(rc == cps_api_ret_code_ERR);
             rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "100::0", 64, vrf, "", "", true);
             ASSERT_TRUE(rc == cps_api_ret_code_ERR);
-            rc = nas_ut_validate_neigh_cfg(vrf, AF_INET6, "100::2", 128, true);
+            rc = nas_ut_validate_neigh_cfg(vrf, AF_INET6, "100::2", 128, true, NULL);
             ASSERT_TRUE(rc == cps_api_ret_code_ERR);
             rc = nas_ut_validate_rt_cfg (vrf, AF_INET6, "60::0", 64, vrf, "", "", true);
             ASSERT_TRUE(rc == cps_api_ret_code_ERR);
@@ -1138,7 +2862,7 @@ TEST(nas_rt_vrf_test, nas_rt_vrf_neg_test) {
 }
 
 TEST(nas_rt_vrf_test, nas_rt_vrf_vlan_del_test) {
-    int ret = system("os10-show-version | grep \"OS_NAME.*Enterprise\"");
+    int ret = system("opx-show-version | grep \"OS_NAME.*Enterprise\"");
     if (ret != 0) {
         return;
     }
@@ -1206,6 +2930,172 @@ TEST(nas_rt_vrf_test, nas_rt_vrf_vlan_del_test) {
     fflush(fp);
     system("sudo -u admin clish --b /tmp/test_pre_req");
     fclose(fp);
+}
+
+static void nas_rt_ecmp_config(bool is_add) {
+    cps_api_return_code_t rc;
+    int ret = system("opx-show-version | grep \"OS_NAME.*Enterprise\"");
+    if (ret != 0) {
+        return;
+    }
+    FILE *fp;
+    char cmd [512];
+
+
+    if (is_add == false) {
+        fp = fopen("/tmp/test_pre_req","w");
+        fprintf(fp, "configure terminal\n");
+        fprintf(fp, "no mac address-table static 00:11:22:33:44:55 vlan 100\n");
+        fprintf(fp, "no mac address-table static 00:11:22:33:44:66 vlan 101\n");
+        fprintf(fp, "no interface vlan 100\n");
+        fprintf(fp, "no interface vlan 101\n");
+        fprintf(fp, "no ip vrf blue\n");
+        fprintf(fp, "end\n");
+        fflush(fp);
+        system("sudo -u admin clish --b /tmp/test_pre_req");
+        fclose(fp);
+
+        sleep(3);
+        rc = nas_ut_validate_neigh_cfg("blue", AF_INET, "100.10.10.2", 128, true, NULL);
+        ASSERT_TRUE(rc != cps_api_ret_code_OK);
+        rc = nas_ut_validate_neigh_cfg("blue", AF_INET, "101.10.10.2", 128, true, NULL);
+        ASSERT_TRUE(rc != cps_api_ret_code_OK);
+        rc = nas_ut_validate_neigh_cfg("blue", AF_INET6, "100::2", 128, true, NULL);
+        ASSERT_TRUE(rc != cps_api_ret_code_OK);
+        rc = nas_ut_validate_neigh_cfg("blue", AF_INET6, "101::2", 128, true, NULL);
+        ASSERT_TRUE(rc != cps_api_ret_code_OK);
+        return;
+    }
+    fp = fopen("/tmp/test_pre_req","w");
+    fprintf(fp, "configure terminal\n");
+    fprintf(fp, "ip vrf blue\n");
+    fprintf(fp, "exit\n");
+
+    fprintf(fp, "interface vlan 100\n");
+    fprintf(fp, "no shutdown\n");
+    fprintf(fp, "ip vrf forwarding blue\n");
+    fprintf(fp, "ip address 100.10.10.1/24\n");
+    fprintf(fp, "ipv6 address 100::1/64\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "interface ethernet %s\n", DoD_b2b_intf1);
+    fprintf(fp, "switchport mode trunk\n");
+    fprintf(fp, "switchport trunk allowed vlan 100\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "mac address-table static 00:11:22:33:44:55 vlan 100 interface ethernet %s\n",
+            DoD_b2b_intf1);
+
+    fprintf(fp, "interface vlan 101\n");
+    fprintf(fp, "no shutdown\n");
+    fprintf(fp, "ip vrf forwarding blue\n");
+    fprintf(fp, "ip address 101.10.10.1/24\n");
+    fprintf(fp, "ipv6 address 101::1/64\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "interface ethernet %s\n", DoD_b2b_intf1);
+    fprintf(fp, "switchport mode trunk\n");
+    fprintf(fp, "switchport trunk allowed vlan 101\n");
+    fprintf(fp, "exit\n");
+    fprintf(fp, "mac address-table static 00:11:22:33:44:66 vlan 101 interface ethernet %s\n",
+            DoD_b2b_intf1);
+    fprintf(fp, "end\n");
+    fflush(fp);
+    system("sudo -u admin clish --b /tmp/test_pre_req");
+    fclose(fp);
+
+    sleep(5);
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip -n blue neigh add 100.10.10.2 lladdr 00:11:22:33:44:55 dev v-br100");
+    system(cmd);
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip -n blue neigh add 101.10.10.2 lladdr 00:11:22:33:44:66 dev v-br101");
+    system(cmd);
+
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip -n blue neigh add 100::2 lladdr 00:11:22:33:44:55 dev v-br100");
+    system(cmd);
+    memset(cmd, '\0', sizeof(cmd));
+    snprintf(cmd, 511, "ip -n blue neigh add 101::2 lladdr 00:11:22:33:44:66 dev v-br101");
+    system(cmd);
+
+    sleep(5);
+    rc = nas_ut_validate_neigh_cfg("blue", AF_INET, "100.10.10.2", 128, true, NULL);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_validate_neigh_cfg("blue", AF_INET, "101.10.10.2", 128, true, NULL);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_validate_neigh_cfg("blue", AF_INET6, "100::2", 128, true, NULL);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_validate_neigh_cfg("blue", AF_INET6, "101::2", 128, true, NULL);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+}
+
+TEST(nas_rt_vrf_test, nas_rt_vrf_ecmp_test) {
+    cps_api_return_code_t rc;
+    nas_rt_ecmp_config(true);
+    FILE *fp = fopen("/tmp/test_pre_req","w");
+    fprintf(fp, "configure terminal\n");
+    fprintf(fp, "ip route vrf blue 30.0.0.0/16 100.10.10.2\n");
+    fprintf(fp, "ip route vrf blue 30.0.0.0/16 101.10.10.2\n");
+    fprintf(fp, "ipv6 route vrf blue 30::/64 100::2\n");
+    fprintf(fp, "ipv6 route vrf blue 30::/64 101::2\n");
+    fprintf(fp, "end\n");
+    fflush(fp);
+    system("sudo -u admin clish --b /tmp/test_pre_req");
+    fclose(fp);
+
+    std::cout<<"Sleeping to download the routes from RTM"<<std::endl;
+    sleep(20);
+
+    rc = nas_ut_validate_rt_ecmp_cfg ("blue", AF_INET, "30.0.0.0", 16, "blue", NULL, NULL, true, 2);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_validate_rt_ecmp_cfg ("blue", AF_INET6,"30::", 64, "blue", NULL, NULL, true, 2);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    std::cout<<"Delete the routes"<<std::endl;
+    fp = fopen("/tmp/test_pre_req","w");
+    fprintf(fp, "configure terminal\n");
+    fprintf(fp, "no ip route vrf blue 30.0.0.0/16 100.10.10.2\n");
+    fprintf(fp, "no ip route vrf blue 30.0.0.0/16 101.10.10.2\n");
+    fprintf(fp, "no ipv6 route vrf blue 30::/64 100::2\n");
+    fprintf(fp, "no ipv6 route vrf blue 30::/64 101::2\n");
+    fprintf(fp, "end\n");
+    fflush(fp);
+    system("sudo -u admin clish --b /tmp/test_pre_req");
+    fclose(fp);
+
+    sleep(3);
+    rc = nas_ut_validate_rt_ecmp_cfg ("blue", AF_INET, "30.0.0.0", 16, "blue", NULL, NULL, true, 2);
+    ASSERT_TRUE(rc != cps_api_ret_code_OK);
+    rc = nas_ut_validate_rt_ecmp_cfg ("blue", AF_INET6,"30::", 64, "blue", NULL, NULL, true, 2);
+    ASSERT_TRUE(rc != cps_api_ret_code_OK);
+    nas_rt_ecmp_config(false);
+}
+
+TEST(nas_rt_vrf_test, nas_rt_vrf_ecmp_test_2nh) {
+
+    cps_api_return_code_t rc;
+    nas_rt_ecmp_config(true);
+    nas_ut_rt_cfg ("blue",1, "30.0.0.0", 16, AF_INET, "blue", "100.10.10.2", "v-br100");
+    nas_ut_rt_cfg ("blue",1, "30::", 64, AF_INET6, NULL, "100::2", "v-br100");
+    /* Use IPv6 route next-hop update model */
+    nas_ut_rt_ipv6_nh_cfg ("blue", true, "30.0.0.0", 16, AF_INET6, NULL, "101.10.10.2", "v-br101", NULL, NULL);
+    nas_ut_rt_ipv6_nh_cfg ("blue", true, "30::", 64, AF_INET6, "blue", "101::2", "v-br101", NULL, NULL);
+    sleep(5);
+
+    rc = nas_ut_validate_rt_ecmp_cfg ("blue", AF_INET, "30.0.0.0", 16, "blue", NULL, NULL, true, 2);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+    rc = nas_ut_validate_rt_ecmp_cfg ("blue", AF_INET6,"30::", 64, "blue", NULL, NULL, true, 2);
+    ASSERT_TRUE(rc == cps_api_ret_code_OK);
+
+    std::cout<<"Delete the routes"<<std::endl;
+    nas_ut_rt_ipv6_nh_cfg ("blue", false, "30.0.0.0", 16, AF_INET6, NULL, "101.10.10.2", "v-br101", NULL, NULL);
+    nas_ut_rt_cfg ("blue",0, "30.0.0.0", 16, AF_INET, "blue", "100.10.10.2", "v-br100");
+    nas_ut_rt_ipv6_nh_cfg ("blue", false, "30::", 64, AF_INET6, NULL, "101::2", "v-br101", NULL, NULL);
+    nas_ut_rt_cfg ("blue",0, "30::", 64, AF_INET6, "blue", "100::2", "v-br100");
+    sleep(3);
+    rc = nas_ut_validate_rt_ecmp_cfg ("blue", AF_INET, "30.0.0.0", 16, "blue", NULL, NULL, true, 2);
+    ASSERT_TRUE(rc != cps_api_ret_code_OK);
+    rc = nas_ut_validate_rt_ecmp_cfg ("blue", AF_INET6,"30::", 64, "blue", NULL, NULL, true, 2);
+    ASSERT_TRUE(rc != cps_api_ret_code_OK);
+    nas_rt_ecmp_config(false);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
* Feature: VxLAN Support
* Bugfix: Refresh mgmt neighbors continuously
* Bugfix: Flush the IPv4 routes (since OS does not send route del event) that are reachable via IP
          subnet upon deleting the IP address.
* Bugfix: If the interface is down, ARP should not be programmed into hardware and the kernel entry
          should be changed to failed state
* Update: Debug dump routines to include multipath object dump
* Update: Modify error log on next hop delete failure to be more informative
* Update: NHT get all for all VRFs supported
* Update: Add support for virtual rif attribute as part of VRRP peer routing MAC configuration
* Update: NHT support for non-default VRF
* Update: Add validations to ensure that on destination change (route/nh/nht), the next-hop id that the NHT
          currently uses will trigger ACL clean-up only if this next-hop id is not
          being used by any other NHT via connected neighbor.
* Update: Process all the routes from change list before deleting the next-hop in the mode change scenario
* Update: LLA programming should be done when one of the LLA satisfies the L3 mode and admin up condition
* Update: Refresh/Resolve the unresolved neighbors during MAC add processing
* Update: Publish the neighbor events during interface mode change when an interface part of non-default
          VRF is getting deleted
* Update: Allow the mgmt interface in the nbr-mgr cache for handling intf events for mgmt neighbors.
* Update: Handle the RIF creation when the local interface DB is not populated
* Update: Change to accomodate event type change for 1d bridge feature

Signed-off-by: Garrick He <garrick_he@dell.com>