### PR TITLE
Feat: OPX 3.2.0-rc1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,11 +13,10 @@
 # See the Apache Version 2.0 License for specific language governing
 # permissions and limitations under the License.
 #
-
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.69])
-AC_INIT([opx-nas-l3], [3.10.1+opx3], [ops-dev@lists.openswitch.net])
+AC_INIT([opx-nas-l3], [3.12.0], [ops-dev@lists.openswitch.net])
 AM_INIT_AUTOMAKE([foreign subdir-objects])
 AC_CONFIG_SRCDIR([.])
 AC_CONFIG_HEADERS([config.h])

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+opx-nas-l3 (3.12.0) unstable; urgency=medium
+
+  * Update: Avoid the ARP/Nbr refresh when the MAC not learnt in the kernel 
+  * Bugfix: Added the NULL check for NH to avoid the crash during best route get for NHT destination.
+  * Update: Use the right size for the vrf-name
+  * Update: Addressed the zero MAC with VXLAN intf case.
+  * Update: Trigger ARP refresh when VXLAN remote MAC moves from one VTEP to another.
+
+ -- Dell EMC <ops-dev@lists.openswitch.net>  Wed, 06 Jun 2019 15:00:00 -0800
+
 opx-nas-l3 (3.10.1+opx3) unstable; urgency=medium
 
   * Update: README copyright placement

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Dell EMC <ops-dev@lists.openswitch.net>
 Build-Depends: debhelper (>= 9),dh-autoreconf,dh-systemd,autotools-dev,libopx-common-dev (>= 1.4.0),
                libopx-nas-common-dev (>= 6.1.0),libopx-cps-dev (>= 3.6.2),libopx-logging-dev (>= 2.1.0),
-               libopx-nas-linux-dev (>= 5.11.0),libopx-nas-ndi-dev (>= 4.6.0),opx-ndi-api-dev (>= 7.5.0),
+               libopx-nas-linux-dev (>= 5.11.0),libopx-nas-ndi-dev, opx-ndi-api-dev (>= 7.5.0),
                libssl-dev,libsystemd-dev
 Standards-Version: 3.9.3
 Vcs-Browser: https://github.com/open-switch/opx-nas-l3
@@ -20,7 +20,7 @@ Package: libopx-nas-l3-dev
 Architecture: any
 Depends: ${misc:Depends},libopx-common-dev (>= 1.4.0),libopx-nas-common-dev (>= 6.1.0),
          libopx-cps-dev (>= 3.6.2),libopx-logging-dev (>= 2.1.0),libopx-nas-linux-dev (>= 5.11.0),
-         libopx-nas-ndi-dev (>= 4.6.0),opx-ndi-api-dev (>= 7.5.0),libopx-nas-l3-1 (=${binary:Version}),
+         libopx-nas-ndi-dev, opx-ndi-api-dev (>= 7.5.0),libopx-nas-l3-1 (=${binary:Version}),
          libopx-base-model-dev (>= 3.109.0)
 Description: This package contains base layer 3 functionality for the Openswitch software.
 

--- a/inc/opx/hal_rt_api.h
+++ b/inc/opx/hal_rt_api.h
@@ -103,4 +103,7 @@ dn_hal_route_err hal_fib_next_hop_add(t_fib_nh *p_nh);
 
 t_std_error _hal_rt_virtual_routing_ip_cfg(nas_rt_virtual_routing_ip_config_t *p_cfg, bool status);
 
+/* scan and update resilient hash attribute for each group */
+void hal_rt_mpath_update_rh_all(void);
+
 #endif /* __HAL_RT_API_H__ */

--- a/inc/opx/hal_rt_route.h
+++ b/inc/opx/hal_rt_route.h
@@ -647,6 +647,7 @@ typedef struct _t_fib_nh {
     uint32_t           clnts_ref_cnt; /* In case of parent NH being referrred by multiple leaked NH,
                                        increment this counter in the parent NH and notify nbr-mgr accordingly
                                        for proactive resolution */
+    uint32_t           flags; /* NextHop flags*/
 } t_fib_nh;
 
 /*
@@ -911,7 +912,7 @@ int fib_destroy_leaked_rt_tree(void);
 
 t_fib_nh *fib_proc_nh_add (uint32_t vrf_id, t_fib_ip_addr *p_ip_addr, uint32_t if_index,
                       t_fib_nh_owner_type owner_type, uint32_t owner_value, bool is_mgmt_nh,
-                      uint32_t parent_vrf_id);
+                      uint32_t parent_vrf_id, uint32_t flags);
 
 int fib_proc_nh_delete (t_fib_nh *p_nh, t_fib_nh_owner_type owner_type, uint32_t owner_value);
 

--- a/inc/opx/nas_rt_api.h
+++ b/inc/opx/nas_rt_api.h
@@ -42,6 +42,14 @@ typedef struct  {
     bool                        eor;
 } nas_route_domain_object_t;
 
+enum {
+    NAS_RT_NBR_FLAGS_PROACTIVE_RESOLVE = 1, /* Start the proactive resolution as long as the intf. is up */
+    NAS_RT_NBR_FLAGS_TRIGGER_RESOLVE, /* Start the resolution just once. */
+    NAS_RT_NBR_FLAGS_DISABLE_AGE_OUT_1D_BRIDGE_REMOTE_MAC, /* Upon neighbor ageout, update the nbr state to reachable. */
+    NAS_RT_NBR_FLAGS_ENABLE_AGE_OUT, /* Upon neighbor ageout, perform the regular age-out handling. */
+    NAS_RT_NBR_FLAGS_UPDATE_PARENT_IF, /* Update the parent and child interfaces mapping for nbr handling. */
+};
+
 typedef struct  {
     unsigned short                  af;
     unsigned long                   vrfid;
@@ -126,6 +134,7 @@ t_std_error nas_route_get_all_arp_info(cps_api_object_list_t list, uint32_t vrf_
 cps_api_return_code_t nas_route_process_cps_peer_routing(cps_api_transaction_params_t * param,
                                         size_t ix);
 t_std_error nas_route_get_all_peer_routing_config(bool is_specific_vrf_get, hal_vrf_id_t vrf_id,
+                                                  char *if_name, hal_mac_addr_t *mac_addr,
                                                   cps_api_object_list_t list);
 
 cps_api_return_code_t nas_route_process_cps_virtual_routing_ip_cfg (cps_api_transaction_params_t * param,
@@ -146,6 +155,8 @@ t_std_error nas_route_get_all_route_info(cps_api_object_list_t list, uint32_t vr
                                          hal_ip_addr_t *p_prefix, uint32_t pref_len, bool is_specific_prefix_get,
                                          bool is_specific_vrf_get);
 cps_api_object_t nas_route_nh_to_nbr_cps_object(t_fib_nh *entry, cps_api_operation_types_t op, bool is_pub);
+t_std_error nas_route_nbr_entry_to_nbr_cps_object(t_fib_neighbour_entry *entry, cps_api_operation_types_t op,
+                                                  uint32_t flags);
 bool nas_route_fdb_add_cps_msg (t_fib_nh *p_nh);
 
 bool nas_route_is_rsvd_intf(hal_ifindex_t nh_if_index);

--- a/inc/opx/nbr-mgr/nbr_mgr_main.h
+++ b/inc/opx/nbr-mgr/nbr_mgr_main.h
@@ -36,8 +36,9 @@
 #define NBR_MGR_NUD_NONE          0x00
 
 #define NBR_MGR_BURST_RESOLVE_CNT 300
-#define NBR_MGR_MIN_NBR_RETRY_CNT 10
-#define NBR_MGR_MAX_NBR_RETRY_CNT 25
+#define NBR_MGR_MAX_NBR_REFRESH_OS_MAC_LEARN_RETRY_CNT 5
+#define NBR_MGR_MIN_NBR_FAILED_RETRY_CNT 10
+#define NBR_MGR_MAX_NBR_FAILED_RETRY_CNT 25
 #define NBR_MGR_MAX_NBR_REFRESH_MAC_LEARN_RETRY_CNT 100
 #define NBR_MGR_INSTANT_RESOLVE_DELAY 0 /* No delay for resolving the ARP/Nbr entries */
 #define NBR_MGR_BURST_RESOLVE_DELAY 1 /* Every 1 sec NBR_MGR_BURST_RESOLVE_CNT ARP
@@ -51,6 +52,15 @@
 #define NBR_MGR_INTF_OPER_MSG  0x4
 #define NBR_MGR_DEFAULT_VRF_ID 0
 
+enum {
+    NBR_MGR_INTF_TYPE_PHY = 1,
+    NBR_MGR_INTF_TYPE_LAG,
+    NBR_MGR_INTF_TYPE_1Q_BRIDGE,
+    NBR_MGR_INTF_TYPE_1D_BRIDGE,
+    NBR_MGR_INTF_TYPE_MACVLAN,
+    NBR_MGR_INTF_TYPE_VXLAN,
+};
+
 /* Today, we get the oper. status in the attribute
  * BASE_IF_LINUX_IF_INTERFACES_INTERFACE_IF_FLAGS, if this is not case in future, change the code. */
 #define NBR_MGR_INTF_OPER_UP (1<<6) /* IFF_RUNNING */
@@ -58,6 +68,14 @@ enum {
     NBR_MGR_AUTO_REFRESH_INIT,
     NBR_MGR_AUTO_REFRESH_ENABLE,
     NBR_MGR_AUTO_REFRESH_DISABLE,
+};
+
+enum {
+    NBR_MGR_NBR_FLAGS_PROACTIVE_RESOLVE = 1, /* Start the proactive resolution as long as the intf. is up */
+    NBR_MGR_NBR_FLAGS_TRIGGER_RESOLVE, /* Start the resolution just once. */
+    NBR_MGR_NBR_FLAGS_DISABLE_AGE_OUT_1D_BRIDGE_REMOTE_MAC, /* Upon neighbor ageout, update the nbr state to reachable. */
+    NBR_MGR_NBR_FLAGS_ENABLE_AGE_OUT, /* Upon neighbor ageout, perform the regular age-out handling. */
+    NBR_MGR_NBR_FLAGS_UPDATE_PARENT_IF, /* Update the parent and child interfaces mapping for nbr handling. */
 };
 
 bool nbr_mgr_cps_init (void);

--- a/inc/opx/nbr-mgr/nbr_mgr_msgq.h
+++ b/inc/opx/nbr-mgr/nbr_mgr_msgq.h
@@ -51,7 +51,8 @@ typedef enum {
     NBR_MGR_NL_DELAY_REFRESH_MSG,
     NBR_MGR_DUMP_MSG,
     NBR_MGR_NL_DELAY_RESOLVE_MSG,
-    NBR_MGR_NL_INSTANT_REFRESH_MSG
+    NBR_MGR_NL_INSTANT_REFRESH_MSG,
+    NBR_MGR_NL_SET_NBR_STATE_MSG
 } nbr_mgr_msg_type_t;
 
 typedef enum {
@@ -75,7 +76,12 @@ typedef enum {
 #define NBR_MGR_NBR_REFRESH      0x2
 #define NBR_MGR_MAC_NOT_PRESENT  0x4
 #define NBR_MGR_NBR_MAC_CHANGE   0x8
-#define NBR_MGR_NBR_REFRESH_FOR_MAC_LEARN  0x10
+#define NBR_MGR_NBR_REFRESH_FOR_MAC_LEARN           0x10
+#define NBR_MGR_NBR_TRIGGER_RESOLVE                 0x20
+#define NBR_MGR_NBR_DISABLE_AGE_OUT_1D_REMOTE_MAC   0x40
+#define NBR_MGR_NBR_ENABLE_AGE_OUT                  0x80
+#define NBR_MGR_NBR_RESOLUTION_IN_PRGS              0x100
+#define NBR_MGR_NBR_UPDATE_PARENT_IF                0x200
 
 typedef struct  {
     unsigned short        family;
@@ -86,7 +92,7 @@ typedef struct  {
     hal_ifindex_t         parent_if;
     hal_ifindex_t         mbr_if_index;
     unsigned long         vrfid;
-    char                  vrf_name[HAL_IF_NAME_SZ + 1];
+    char                  vrf_name[NAS_VRF_NAME_SZ + 1];
     unsigned long         expire;
     unsigned long         flags;
     unsigned long         status;
@@ -101,13 +107,18 @@ typedef struct {
     bool is_bridge;
     uint32_t vlan_id;
     uint32_t flags;
+    uint32_t type; /* Interface type */
     unsigned long vrfid;
     hal_ifindex_t parent_or_child_if_index; /* If-index of the router interface in VRF context (child intf)
                                                or parent interface */
     unsigned long parent_or_child_vrfid; /* VRF-id of the router interface in VRF context (child VRF-id or
                                             parent VRF-id */
+    hal_ifindex_t mbr_if_index;
     char vrf_name[NAS_VRF_NAME_SZ + 1];
     char if_name[HAL_IF_NAME_SZ + 1]; /* interface name */
+    bool is_parent_and_child_in_same_vrf; /* This is set to TRUE when parent and
+                                             MAC VLAN interfaces are in the same VRF. */
+    bool is_child_intf; /* This is the child interface on parent intf (parent_or_child_if_index). */
 } nbr_mgr_intf_entry_t;
 
 typedef struct {

--- a/nbr-mgr/src/nbr_mgr_debug.cpp
+++ b/nbr-mgr/src/nbr_mgr_debug.cpp
@@ -126,11 +126,13 @@ void _nbr_mgr_dump_all_nbr_stats_clear(nbr_data const * ptr) {
 
 void nbr_mgr_dump_mac_data(mac_data_ptr ptr) {
     NBR_MGR_LOG_ERR("DUMP", "MAC entry MAC:%s, ifindex:%d, mbr_if_index:%d, FDB type:%d valid:%d learnt-first:%d "
-                    " add-cnt:%d add-no-mbr-cnt:%d del-cnt:%d",
+                    " add-cnt:%d add-no-mbr-cnt:%d del-cnt:%d IP:%s",
                     ptr->get_mac_addr().c_str(), ptr->get_mac_intf(),
                     ptr->get_mac_phy_if(), static_cast<int>(ptr->get_fdb_type()), ptr->is_valid(),
                     ptr->get_mac_learnt_flag(), ptr->fdb_get_msg_cnt(true), ptr->fdb_get_msg_no_mbr_cnt(),
-                    ptr->fdb_get_msg_cnt(false));
+                    ptr->fdb_get_msg_cnt(false),
+                    ((ptr->get_mac_remote_ip().af_index == HAL_INET4_FAMILY) ?
+                     nbr_ip_addr_string (ptr->get_mac_remote_ip()).c_str() : ""));
 }
 
 

--- a/nbr-mgr/src/nbr_mgr_rslv.cpp
+++ b/nbr-mgr/src/nbr_mgr_rslv.cpp
@@ -115,6 +115,7 @@ static cps_api_object_t nbr_mgr_nbr_to_cps_obj(nbr_mgr_nbr_entry_t *entry,cps_ap
     cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_IFINDEX,entry->if_index);
 
     cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_FLAGS,entry->flags);
+    cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_STATE,entry->status);
     if (entry->status & NBR_MGR_NUD_PERMANENT) {
         cps_api_object_attr_add_u32(obj,BASE_ROUTE_OBJ_NBR_TYPE,BASE_ROUTE_RT_TYPE_STATIC);
     } else {
@@ -140,6 +141,9 @@ static char *nbr_mgr_nl_neigh_state_to_str (int type) {
             break;
         case NBR_MGR_NL_DELAY_REFRESH_MSG:
             snprintf (str, sizeof(str), "Delay Refresh");
+            break;
+        case NBR_MGR_NL_SET_NBR_STATE_MSG:
+            snprintf (str, sizeof(str), "State Update");
             break;
         default:
             snprintf (str, sizeof(str), "Unknown");
@@ -182,6 +186,8 @@ bool nbr_mgr_burst_resolve_handler(nbr_mgr_msg_t *p_msg) {
                (p_msg->type == NBR_MGR_NL_INSTANT_REFRESH_MSG) ||
                (p_msg->type == NBR_MGR_NL_DELAY_REFRESH_MSG)) {
         nas_os_refresh_neighbor(obj);
+    } else if (p_msg->type == NBR_MGR_NL_SET_NBR_STATE_MSG) {
+        nas_os_set_neighbor_state(obj);
     }
     cps_api_object_delete(obj);
     return true;

--- a/scripts/init/opx-nbmgr.service
+++ b/scripts/init/opx-nbmgr.service
@@ -24,7 +24,7 @@ OnFailure=service_onfailure@%n.service
 Type=notify
 EnvironmentFile=/etc/opx/opx-environment
 ExecStart=/usr/bin/base_nbr_mgr_svc
-TimeoutStartSec=180
+TimeoutStartSec=90
 
 [Install]
 WantedBy=multi-user.target

--- a/src/hal_rt_debug.c
+++ b/src/hal_rt_debug.c
@@ -1736,17 +1736,20 @@ void fib_dump_mp_info_per_vrf_per_af (uint32_t vrf_id, uint32_t af_index)
     memset(&key, 0, sizeof(key));
 
     p_rt_head = std_radix_getnext (hal_rt_access_fib_vrf_mp_md5_tree(vrf_id,
-                                    af_index), (uint8_t *) &key,
-                                    HAL_RT_MP_MD5_NODE_TREE_KEY_SIZE);
+                af_index), (uint8_t *) &key,
+            HAL_RT_MP_MD5_NODE_TREE_KEY_SIZE);
 
-    if (p_rt_head == NULL)
-    {
-        return;
+    while(p_rt_head) {
+        p_mp_md5_node = (t_fib_mp_md5_node *) p_rt_head;
+
+        fib_dump_mp_md5_node (p_mp_md5_node, true);
+
+        memcpy(&key, &(p_mp_md5_node->key), sizeof(t_fib_mp_md5_node_key));
+        p_rt_head = std_radix_getnext (hal_rt_access_fib_vrf_mp_md5_tree(vrf_id,
+                    af_index), (uint8_t *) &key,
+                HAL_RT_MP_MD5_NODE_TREE_KEY_SIZE);
     }
 
-    p_mp_md5_node = (t_fib_mp_md5_node *) p_rt_head;
-
-    fib_dump_mp_md5_node (p_mp_md5_node, true);
     return;
 }
 

--- a/src/hal_rt_leak.c
+++ b/src/hal_rt_leak.c
@@ -374,7 +374,7 @@ t_std_error hal_rt_leaked_nbr_prg(hal_vrf_id_t vrf_id, t_fib_nh *p_fh, bool is_a
 
     if (is_add) {
         p_nh = fib_proc_nh_add (vrf_id, &p_fh->key.ip_addr,
-                                p_fh->key.if_index, FIB_NH_OWNER_TYPE_ARP, 0, false, p_fh->vrf_id);
+                                p_fh->key.if_index, FIB_NH_OWNER_TYPE_ARP, 0, false, p_fh->vrf_id, 0);
         if (p_nh == NULL) {
             HAL_RT_LOG_ERR("LEAK-NBR-PRG", "NH addition failed. "
                            "Leaked VRF:%d parent VRF:%d, ip_addr:%s, if_index: %d",

--- a/src/hal_rt_nh.c
+++ b/src/hal_rt_nh.c
@@ -238,7 +238,7 @@ int fib_destroy_intf_tree (void)
 
 t_fib_nh *fib_proc_nh_add (uint32_t vrf_id, t_fib_ip_addr *p_ip_addr,
                       uint32_t if_index, t_fib_nh_owner_type owner_type, uint32_t owner_value,
-                      bool is_mgmt_nh, uint32_t parent_vrf_id)
+                      bool is_mgmt_nh, uint32_t parent_vrf_id, uint32_t flags)
 {
     t_fib_nh    *p_nh = NULL;
     bool   resolve_nh = false;
@@ -280,6 +280,7 @@ t_fib_nh *fib_proc_nh_add (uint32_t vrf_id, t_fib_ip_addr *p_ip_addr,
         p_nh->vrf_id = vrf_id;
         p_nh->parent_vrf_id = parent_vrf_id;
         p_nh->is_mgmt_nh = is_mgmt_nh;
+        p_nh->flags = flags;
 
         fib_create_nh_dep_dr_tree (p_nh);
         if (vrf_id != parent_vrf_id) {
@@ -396,7 +397,8 @@ t_fib_nh *fib_proc_nh_add (uint32_t vrf_id, t_fib_ip_addr *p_ip_addr,
         fib_resolve_connected_tunnel_nh (vrf_id, p_nh);
     }
 
-    if ((is_mgmt_nh== false) && (!(STD_IP_IS_ADDR_ZERO(&p_nh->key.ip_addr))) &&
+    if ((is_mgmt_nh== false) && (flags != FIB_RT_NH_FLAGS_ONLINK) &&
+        (!(STD_IP_IS_ADDR_ZERO(&p_nh->key.ip_addr))) &&
         (((owner_type == FIB_NH_OWNER_TYPE_RTM) && (!FIB_IS_NH_OWNER_CLIENT(p_nh))
           && (p_nh->rtm_ref_count == 1)) ||
          ((owner_type == FIB_NH_OWNER_TYPE_CLIENT) && (p_nh->rtm_ref_count == 0))))
@@ -493,7 +495,8 @@ int fib_proc_nh_delete (t_fib_nh *p_nh, t_fib_nh_owner_type owner_type,
         FIB_RESET_NH_OWNER (p_nh, owner_type, owner_value);
     }
 
-    if ((p_nh->is_mgmt_nh == false) && (!(STD_IP_IS_ADDR_ZERO(&p_nh->key.ip_addr))) &&
+    if ((p_nh->is_mgmt_nh == false) && (p_nh->flags != FIB_RT_NH_FLAGS_ONLINK) &&
+        (!(STD_IP_IS_ADDR_ZERO(&p_nh->key.ip_addr))) &&
         (((owner_type == FIB_NH_OWNER_TYPE_RTM) && (!FIB_IS_NH_OWNER_CLIENT(p_nh))
           && (p_nh->rtm_ref_count == 0)) ||
          ((owner_type == FIB_NH_OWNER_TYPE_CLIENT) && (p_nh->rtm_ref_count == 0))))

--- a/src/nas_rt_mac.cpp
+++ b/src/nas_rt_mac.cpp
@@ -97,10 +97,10 @@ bool nas_rt_peer_mac_db_add (nas_rt_peer_mac_config_t* mac_info)
     nas_rt_mac_uptr_t mac_uptr (new nas_rt_peer_mac_config_t (*mac_info));
     nas_rt_db_add_peer_mac_list (mac_uptr);
 
-    HAL_RT_LOG_INFO("HAL-RT", "Vrf:%d if-name:%s peer-mac:%s vrf obj:0x%lx rif obj:0x%lx "
+    HAL_RT_LOG_INFO("HAL-RT", "Vrf:%d if-name:%s peer-mac:%s ingres-only:%d vrf obj:0x%lx rif obj:0x%lx "
                     "added successfully", mac_info->vrf_id, mac_info->if_name,
                     hal_rt_mac_to_str(&mac_info->mac, p_buf, MAC_STR_LEN),
-                    mac_info->vrf_obj_id, mac_info->rif_obj_id);
+                    mac_info->ingress_only, mac_info->vrf_obj_id, mac_info->rif_obj_id);
     return true;
 }
 
@@ -160,6 +160,7 @@ void fib_dump_peer_mac_db_get_all_with_vrf(hal_vrf_id_t vrf_id)
 }
 
 t_std_error nas_route_get_all_peer_routing_config(bool is_specific_vrf_get, hal_vrf_id_t filter_vrf_id,
+                                                  char *if_name, hal_mac_addr_t *mac_addr,
                                                   cps_api_object_list_t list){
 
     t_fib_vrf      *p_vrf = NULL;
@@ -188,6 +189,16 @@ t_std_error nas_route_get_all_peer_routing_config(bool is_specific_vrf_get, hal_
 
         for(auto& x: mac_list){
             nas_rt_peer_mac_config_t *ptr = x.second.get();
+            if ((if_name) &&
+                (memcmp(if_name, ptr->if_name, sizeof(ptr->if_name)))) {
+                continue;
+            }
+
+            if ((mac_addr) &&
+                (memcmp(*mac_addr, ptr->mac, sizeof(ptr->mac)))) {
+                continue;
+            }
+
             cps_api_object_t obj = nas_route_peer_routing_config_to_cps_object(vrf_id, ptr);
             if(obj == NULL) {
                 continue;

--- a/src/nas_rt_nht.c
+++ b/src/nas_rt_nht.c
@@ -350,18 +350,18 @@ int nas_rt_find_next_best_dr_for_nht(t_fib_nht *p_fib_nht, int vrf_id, t_fib_ip_
         p_best_dr = fib_get_next_best_fit_dr(vrf_id, &p_best_dr->key.prefix, p_best_dr->prefix_len);
     }
     if (*is_next_best_rt_found == false) {
-        if (is_conn_route_found) {
+        if (p_nh && is_conn_route_found) {
             /* There is a connected route to reach the NHT nexthop, resolve the NH thru Nbr-Mgr */
             if (p_nh->vrf_id != p_nh->parent_vrf_id) {
                 t_fib_nh *p_parent_nh = fib_get_nh (p_nh->parent_vrf_id, dest_addr, p_nh->key.if_index);
                 if (p_parent_nh == NULL) {
                     /* If parent NH is not present, create it before creating the leaked NH */
                     fib_proc_nh_add (p_nh->parent_vrf_id, dest_addr, p_nh->key.if_index,
-                                     FIB_NH_OWNER_TYPE_CLIENT, 0, false, p_nh->parent_vrf_id);
+                                     FIB_NH_OWNER_TYPE_CLIENT, 0, false, p_nh->parent_vrf_id, 0);
                 }
             }
             fib_proc_nh_add (vrf_id, dest_addr, p_nh->key.if_index,
-                             FIB_NH_OWNER_TYPE_CLIENT, 0, false, parent_vrf_id);
+                             FIB_NH_OWNER_TYPE_CLIENT, 0, false, parent_vrf_id, 0);
         }
         return STD_ERR_OK;
     }
@@ -684,12 +684,12 @@ int nas_rt_handle_dest_change(t_fib_dr *p_dr, t_fib_nh *p_nh, bool is_add) {
                         if (p_parent_nh == NULL) {
                             /* If parent NH is not present, create it before creating the leaked NH */
                             fib_proc_nh_add (p_fh->parent_vrf_id, &p_fib_nht->key.dest_addr, p_fh->key.if_index,
-                                             FIB_NH_OWNER_TYPE_CLIENT, 0, false, p_fh->parent_vrf_id);
+                                             FIB_NH_OWNER_TYPE_CLIENT, 0, false, p_fh->parent_vrf_id, 0);
                         }
                     }
 
                     fib_proc_nh_add (p_fib_nht->vrf_id, &p_fib_nht->key.dest_addr,
-                                     p_fh->key.if_index, FIB_NH_OWNER_TYPE_CLIENT, 0, false, parent_vrf_id);
+                                     p_fh->key.if_index, FIB_NH_OWNER_TYPE_CLIENT, 0, false, parent_vrf_id, 0);
                     /* Check if this Route is better match for NHT(s) */
                 } else if ((!(FIB_IS_AFINDEX_VALID (p_fib_nht->fib_match_dest_addr.af_index)) &&
                             (STD_IP_IS_ADDR_ZERO(&p_fib_nht->fib_match_dest_addr))) ||
@@ -944,12 +944,12 @@ int nas_rt_handle_nht (t_fib_nht *p_nht_info, bool is_add, bool is_force_del) {
             if (p_parent_nh == NULL) {
                 /* If parent NH is not present, create it before creating the leaked NH */
                 fib_proc_nh_add (p_nh->parent_vrf_id, &p_nht_info->key.dest_addr, p_nh->key.if_index,
-                                 FIB_NH_OWNER_TYPE_CLIENT, 0, false, p_nh->parent_vrf_id);
+                                 FIB_NH_OWNER_TYPE_CLIENT, 0, false, p_nh->parent_vrf_id, 0);
             }
         }
 
         fib_proc_nh_add (p_nht_info->vrf_id, &p_nht_info->key.dest_addr,
-                         p_nh->key.if_index, FIB_NH_OWNER_TYPE_CLIENT, 0, false, p_nh->parent_vrf_id);
+                         p_nh->key.if_index, FIB_NH_OWNER_TYPE_CLIENT, 0, false, p_nh->parent_vrf_id, 0);
         if (p_nh->p_arp_info->state != FIB_ARP_RESOLVED) {
             return STD_ERR_OK;
         }

--- a/src/unit_test/ip_redirect_cfg_test.py
+++ b/src/unit_test/ip_redirect_cfg_test.py
@@ -94,7 +94,7 @@ def handle_show(vrf, ifname):
 def test_pre_req_cfg():
     #print("Test pre requisite config")
     mode = 'OPX'
-    ret = exec_shell('opx-show-version | grep \"OS_NAME.*Enterprise\"')
+    ret = exec_shell('os10-show-version | grep \"OS_NAME.*Enterprise\"')
     if ret:
         mode = 'DoD'
 

--- a/src/unit_test/nas_route_cps_nht_unittest.cpp
+++ b/src/unit_test/nas_route_cps_nht_unittest.cpp
@@ -36,20 +36,20 @@
 
 #include <ctime>
 #include <chrono>
-#include <iomanip>
 
 #include <gtest/gtest.h>
 #include <iostream>
+#include <iomanip>
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <net/if.h>
 #include "nas_ndi_obj_id_table.h"
 
-const char *p_dut_intf1 = "e101-001-0";
-const char *p_dut_intf2 = "e101-004-0";
-const char *p_tr_intf1 = "e101-001-0";
-const char *p_tr_intf2 = "e101-004-0";
+static const char *p_dut_intf1 = "e101-001-0";
+static const char *p_dut_intf2 = "e101-004-0";
+//const char *p_tr_intf1 = "e101-001-0";
+//const char *p_tr_intf2 = "e101-004-0";
 
 /* Constants for IPv4 NHT */
 const char *p_dut_ip_intf1 = "20.0.0.1";
@@ -69,16 +69,16 @@ int pref_len1 = 8, pref_len2 = 16, pref_len3 = 24, pref_len4 = 32, pref_len5 = 2
 int af = AF_INET;
 
 /* Constants for IPv6 NHT */
-const char *p_dut_ip6_intf1 = "2::1";
-const char *p_dut_ip6_intf2 = "3::1";
-const char *p_tr_ip6_intf1 = "2::2";
-const char *p_tr_ip6_2_intf1 = "2::3";
-const char *p_tr_ip6_3_intf1 = "2::4";
-const char *p_tr_ip6_intf2 = "3::2";
-const char *p_tr_ip6_2_intf2 = "3::2";
-const char *p_tr_ip6_3_intf2 = "3::2";
-const char *p_tr_mpath_ip6_intf1 = "2::";
-const char *p_tr_mpath_ip6_intf2 = "3::";
+static const char *p_dut_ip6_intf1 = "2::1";
+static const char *p_dut_ip6_intf2 = "3::1";
+static const char *p_tr_ip6_intf1 = "2::2";
+static const char *p_tr_ip6_2_intf1 = "2::3";
+static const char *p_tr_ip6_3_intf1 = "2::4";
+static const char *p_tr_ip6_intf2 = "3::2";
+static const char *p_tr_ip6_2_intf2 = "3::2";
+static const char *p_tr_ip6_3_intf2 = "3::2";
+static const char *p_tr_mpath_ip6_intf1 = "2::";
+static const char *p_tr_mpath_ip6_intf2 = "3::";
 
 const char *nht6_1 = "4::1", *nht6_2 = "4:1:1::1", *nht6_3 = "4:1:1::2", *nht6_4 = "4:1:2::1",
       *nht6_5 = "4:2::1", *nht6_6= "4::3", *rt6_1="4::", *rt6_2 = "4:1::", *rt6_3 = "4:1:1::", *rt6_4 = "4:1:1::1", *rt6_5 = "::";
@@ -171,7 +171,8 @@ void nht_config_scale_with_prefix (const char *ip_str, uint32_t af_family, bool 
     if (af_family == AF_INET6) {
         char route_str[INET6_ADDRSTRLEN];
         inet_pton(AF_INET6, ip_str, &a6);
-        memcpy (route_str, ip_str, INET6_ADDRSTRLEN);
+        int len = strlen(ip_str);
+        memcpy (route_str, ip_str, ((len > INET6_ADDRSTRLEN)?(INET6_ADDRSTRLEN):len));
         for (; cnt < num_entries; cnt++) {
             //printf ("nht_config_scale_with_prefix %s\r\n", route_str);
             nht_add_del ((void *) &a6, af_family, is_add);
@@ -203,7 +204,7 @@ void nht_add_route_2nh (const char *route_prefix, int pref_len, const char *next
     memset(cmd, '\0', sizeof(cmd));
     snprintf(cmd, 511, "ip route add %s/%d scope global nexthop via %s nexthop via %s",
             route_prefix, pref_len, next_hop_ip1, next_hop_ip2);
-    if(system(cmd));
+    (void)system(cmd);
 
     if (g_scaled_test == false) sleep(2);
 }
@@ -214,7 +215,7 @@ void nht_replace_route_2nh (const char *route_prefix, int pref_len, const char *
     memset(cmd, '\0', sizeof(cmd));
     snprintf(cmd, 511, "ip route replace %s/%d scope global nexthop via %s nexthop via %s",
             route_prefix, pref_len, next_hop_ip1, next_hop_ip2);
-    if(system(cmd));
+    (void)system(cmd);
     sleep(2);
 }
 
@@ -224,7 +225,7 @@ void nht_del_route_2nh (const char *route_prefix, int pref_len, const char *next
     memset(cmd, '\0', sizeof(cmd));
     snprintf(cmd, 511, "ip route del %s/%d scope global nexthop via %s nexthop via %s",
             route_prefix, pref_len, next_hop_ip1, next_hop_ip2);
-    if(system(cmd));
+    (void)system(cmd);
     if (g_scaled_test == false) sleep(2);
 }
 
@@ -237,7 +238,7 @@ void nht_add_route (const char *route_prefix, int pref_len, const char *next_hop
     } else {
         snprintf(cmd, 511, "ip -6 route add %s/%d via %s",route_prefix, pref_len, next_hop_ip);
     }
-    if(system(cmd));
+    (void)system(cmd);
     if (g_scaled_test == false) sleep(1);
 }
 
@@ -250,7 +251,8 @@ void nht_add_route_scale (const char *route_prefix_str, int pref_len, const char
         struct in6_addr a;
 
         inet_pton(AF_INET6, route_prefix_str, &a);
-        memcpy (route_str, route_prefix_str, INET6_ADDRSTRLEN);
+        int len = strlen(route_prefix_str);
+        memcpy (route_str, route_prefix_str, ((len > INET6_ADDRSTRLEN)?(INET6_ADDRSTRLEN):len));
         for (; cnt < num_routes; cnt++) {
             //printf ("add_route scale %s\r\n", route_str);
             nht_add_route (route_str, pref_len, next_hop_ip);
@@ -263,7 +265,8 @@ void nht_add_route_scale (const char *route_prefix_str, int pref_len, const char
         struct in_addr a;
 
         inet_aton(route_prefix_str,&a);
-        memcpy (route_str, route_prefix_str, INET_ADDRSTRLEN);
+        int len = strlen(route_prefix_str);
+        memcpy (route_str, route_prefix_str, ((len > INET_ADDRSTRLEN)?(INET_ADDRSTRLEN):len));
         for (; cnt < num_routes; cnt++) {
             //printf ("add_route scale %s\r\n", route_str);
             nht_add_route (route_str, pref_len, next_hop_ip);
@@ -285,7 +288,7 @@ void nht_del_route (const char *route_prefix, int pref_len, const char *next_hop
     } else {
         snprintf(cmd, 511, "ip -6 route del %s/%d via %s",route_prefix, pref_len, next_hop_ip);
     }
-    if(system(cmd));
+    (void)system(cmd);
     if (g_scaled_test == false) sleep(1);
 }
 
@@ -297,7 +300,8 @@ void nht_del_route_scale (const char *route_prefix_str, int pref_len, const char
         struct in6_addr a;
 
         inet_pton(AF_INET6, route_prefix_str, &a);
-        memcpy (route_str, route_prefix_str, INET6_ADDRSTRLEN);
+        int len = strlen(route_prefix_str);
+        memcpy (route_str, route_prefix_str, ((len > INET6_ADDRSTRLEN)?(INET6_ADDRSTRLEN):len));
         for (; cnt < num_routes; cnt++) {
             printf ("del_route scale %s\r\n", route_str);
             nht_add_route (route_str, pref_len, next_hop_ip);
@@ -311,7 +315,8 @@ void nht_del_route_scale (const char *route_prefix_str, int pref_len, const char
         char route_str[INET_ADDRSTRLEN];
 
         inet_aton(route_prefix_str,&a);
-        memcpy (route_str, route_prefix_str, INET_ADDRSTRLEN);
+        int len = strlen(route_prefix_str);
+        memcpy (route_str, route_prefix_str, ((len > INET_ADDRSTRLEN)?(INET_ADDRSTRLEN):len));
         for (; cnt < num_routes; cnt++) {
             //            printf ("del_route scale %s\r\n", route_str);
             nht_del_route (route_str, pref_len, next_hop_ip);
@@ -333,10 +338,10 @@ void nht_replace_route (const char *route_prefix, int pref_len, const char *next
         snprintf(cmd, 511, "ip route replace %s/%d via %s",route_prefix, pref_len, next_hop_ip);
     } else {
         snprintf(cmd, 511, "ip -6 route del %s/%d",route_prefix, pref_len);
-        if(system(cmd));
+        (void)system(cmd);
         snprintf(cmd, 511, "ip -6 route add %s/%d via %s",route_prefix, pref_len, next_hop_ip);
     }
-    if(system(cmd));
+    (void)system(cmd);
     sleep(2);
 }
 
@@ -350,7 +355,7 @@ void nht_add_static_arp (const char *ip, const char *mac, const char *intf)
     } else {
         snprintf(cmd, 511, "ip -6 neigh add %s lladdr %s dev %s",ip, mac, intf);
     }
-    if(system(cmd));
+    (void)system(cmd);
     sleep(2);
 }
 
@@ -364,14 +369,12 @@ void nht_del_static_arp (const char *ip, const char *intf)
     else {
         snprintf(cmd, 511, "ip -6 neigh del %s dev %s",ip, intf);
     }
-    if(system(cmd));
+    (void)system(cmd);
     sleep(2);
 }
 
 void nht_resolve_nh(const char *ip)
 {
-    return;
-
     char cmd[512];
     memset(cmd, '\0', sizeof(cmd));
     if (af == AF_INET) {
@@ -379,8 +382,9 @@ void nht_resolve_nh(const char *ip)
     } else {
         snprintf(cmd, 511, "ping6 -c 1 %s",ip);
     }
-    if(system(cmd));
+    (void)system(cmd);
     sleep(2);
+    return;
 }
 
 void nht_intf_admin_set(const char *p_b2b_intf, bool is_up)
@@ -390,14 +394,14 @@ void nht_intf_admin_set(const char *p_b2b_intf, bool is_up)
     memset(cmd, '\0', sizeof(cmd));
     snprintf(cmd, 511, "ifconfig %s %s",p_b2b_intf,
             ((is_up) ? "up" : "down"));
-    if(system(cmd));
+    (void)system(cmd);
     if ((af == AF_INET6) && is_up) {
         /* Incase of IPv6, admin down clears the ipv6 address on interface,
          * need to reconfigure on admin up again */
         snprintf(cmd, 511, "ifconfig %s inet6 add %s/64 up",p_dut_intf1, p_dut_ip_intf1);
-        if(system(cmd));
+        (void)system(cmd);
         snprintf(cmd, 511, "ifconfig %s inet6 add %s/64 up",p_dut_intf2, p_dut_ip_intf2);
-        if(system(cmd));
+        (void)system(cmd);
     }
     if (g_scaled_test == false) sleep(2);
 }
@@ -1908,7 +1912,7 @@ int nas_rt_nht_ut_9_1 (bool is_prereq) {
         snprintf(nh_mac, NAS_UT_NH_STR_LEN-1, "00:20:00:00:02:%x", cnt);
         nht_add_static_arp(nh_ip, nh_mac, p_dut_intf1);
         snprintf(rt_nh, NAS_UT_NH_STR_LEN-1, "nexthop via %s ", nh_ip);
-        strcat(p_nh, rt_nh);
+        strncat(p_nh, rt_nh, 2048);
         if (af == AF_INET) {
             snprintf(nh_ip, NAS_UT_NH_STR_LEN-1, "%s%d", p_tr_mpath_intf2, cnt);
         } else {
@@ -1917,7 +1921,7 @@ int nas_rt_nht_ut_9_1 (bool is_prereq) {
         snprintf(nh_mac, NAS_UT_NH_STR_LEN-1, "00:30:00:00:02:%x", cnt);
         nht_add_static_arp(nh_ip, nh_mac, p_dut_intf2);
         snprintf(rt_nh, NAS_UT_NH_STR_LEN-1, "nexthop via %s ", nh_ip);
-        strcat(p_nh, rt_nh);
+        strncat(p_nh, rt_nh, 2048);
     }
     memset(p_cmd, '\0', sizeof(2048));
     if (af == AF_INET) {
@@ -1926,7 +1930,7 @@ int nas_rt_nht_ut_9_1 (bool is_prereq) {
         snprintf(p_cmd, 2047, "ip -6 route add %s/%d %s",rt1, pref_len1, p_nh);
     }
     printf("\r\n %s \r\n",p_cmd);
-    if(system(p_cmd));
+    (void)system(p_cmd);
     nht_config(nht1, af, 1);
     ret = nas_rt_nht_validate_util (nht1, num_nh_entries, rt1, pref_len1);
     nas_rt_nht_print_result ( "TC_9_1: multipath route for NHT", ret);
@@ -1958,7 +1962,7 @@ int nas_rt_nht_ut_9_1 (bool is_prereq) {
     } else {
         snprintf(p_cmd, 2047, "ip -6 route del %s/%d %s",rt1, pref_len1, p_nh);
     }
-    if(system(p_cmd));
+    (void)system(p_cmd);
 
     nht_intf_admin_set(p_dut_intf1,0);
     nht_intf_admin_set(p_dut_intf1,1);
@@ -2065,7 +2069,7 @@ void nas_route_dump_nht_object_content(cps_api_object_t obj){
             auto it = nh_opaque_data_table.begin();
             std::cout<<"NPU-id/NH-id:\t";
             std::cout<<it->first<<"/0x" <<std::hex<<it->second;
-            std::cout<<'\n';
+            std::cout << std::resetiosflags(std::ios_base::basefield) << '\n' << std::endl;
         }
     }
 
@@ -2313,11 +2317,11 @@ TEST(std_nas_route_test, nas_nht_ut_9_1) {
 void nas_rt_nht_route_info() {
 
     if (af == AF_INET) {
-        if(system("ip route show"));
-        if(system("ip neigh show"));
+        (void)system("ip route show");
+        (void)system("ip neigh show");
     } else {
-        if(system("ip -6 route show"));
-        if(system("ip -6 neigh show"));
+        (void)system("ip -6 route show");
+        (void)system("ip -6 neigh show");
     }
 }
 
@@ -2456,18 +2460,18 @@ int main(int argc, char **argv) {
   char cmd[512];
   memset(cmd, '\0', sizeof(cmd));
   snprintf(cmd, 511, "brctl delif br1 %s",p_dut_intf1);
-  if(system(cmd));
+  (void)system(cmd);
   snprintf(cmd, 511, "brctl delif br1 %s",p_dut_intf2);
-  if(system(cmd));
+  (void)system(cmd);
   memset(cmd, '\0', sizeof(cmd));
   printf("\r\n argv[0]:%s argv[1]:%s argv[2]:%s\r\n", argv[0], argv[1], argv[2]);
   if ((argv[1] == NULL) || (strncmp(argv[1], "ipv4",4) == 0)){
       /* Default execution mode is IPv4 */
       printf("\r\n NHT for af-IPv4 execution started! \r\n");
       snprintf(cmd, 511, "ifconfig %s %s/16 up",p_dut_intf1, p_dut_ip_intf1);
-      if(system(cmd));
+      (void)system(cmd);
       snprintf(cmd, 511, "ifconfig %s %s/16 up",p_dut_intf2, p_dut_ip_intf2);
-      if(system(cmd));
+      (void)system(cmd);
   } else if ((argv[1]) && (strncmp(argv[1], "ipv6",4) == 0)) {
       printf("\r\n NHT for af-IPv6 execution started! \r\n");
       p_dut_ip_intf1 = p_dut_ip6_intf1; p_dut_ip_intf2 = p_dut_ip6_intf2;
@@ -2480,9 +2484,9 @@ int main(int argc, char **argv) {
       pref_len4 = pref_len6_4; p_tr_mpath_intf1 = p_tr_mpath_ip6_intf1; p_tr_mpath_intf2 = p_tr_mpath_ip6_intf2;
       af = af6;
       snprintf(cmd, 511, "ifconfig %s inet6 add %s/64 up",p_dut_intf1, p_dut_ip_intf1);
-      if(system(cmd));
+      (void)system(cmd);
       snprintf(cmd, 511, "ifconfig %s inet6 add %s/64 up",p_dut_intf2, p_dut_ip_intf2);
-      if(system(cmd));
+      (void)system(cmd);
   }
   printf("___________________________________________\n");
 
@@ -2494,13 +2498,13 @@ int main(int argc, char **argv) {
    * #RateLimitInterval=30s      ==> RateLimitBurst=0
    * SystemMaxUse=50M         ==> SystemMaxUse=250M
    */
-  if(system("sed -i '/SystemMaxUse=50M/c SystemMaxUse=250M' /etc/systemd/journald.conf"));
-  if(system("sed -i '/#RateLimitInterval=30s/c RateLimitInterval=0s' /etc/systemd/journald.conf"));
-  if(system("sed -i '/#RateLimitBurst=1000/c RateLimitBurst=0' /etc/systemd/journald.conf"));
-  if(system("service systemd-journald restart"));
+  (void)system("sed -i '/SystemMaxUse=50M/c SystemMaxUse=250M' /etc/systemd/journald.conf");
+  (void)system("sed -i '/#RateLimitInterval=30s/c RateLimitInterval=0s' /etc/systemd/journald.conf");
+  (void)system("sed -i '/#RateLimitBurst=1000/c RateLimitBurst=0' /etc/systemd/journald.conf");
+  (void)system("service systemd-journald restart");
 
-  if(system("opx-logging enable ROUTE INFO"));
-  if(system("kill -USR1 `pidof base_nas`"));
+  (void)system("os10-logging enable ROUTE INFO");
+  (void)system("kill -USR1 `pidof base_nas`");
 
   if (RUN_ALL_TESTS())
   {
@@ -2510,12 +2514,12 @@ int main(int argc, char **argv) {
   printf ("\r\n !!! Test Completed !!! \r\n");
 
   /* revert back logging related changes done for executing the UT */
-  if(system("opx-logging disable ROUTE INFO"));
-  if(system("kill -USR1 `pidof base_nas`"));
+  (void)system("os10-logging disable ROUTE INFO");
+  (void)system("kill -USR1 `pidof base_nas`");
 
-  if(system("sed -i '/SystemMaxUse=250M/c SystemMaxUse=50M' /etc/systemd/journald.conf"));
-  if(system("sed -i '/RateLimitInterval=0s/c #RateLimitInterval=30s' /etc/systemd/journald.conf"));
-  if(system("sed -i '/RateLimitBurst=0/c #RateLimitBurst=1000' /etc/systemd/journald.conf"));
-  if(system("service systemd-journald restart"));
+  (void)system("sed -i '/SystemMaxUse=250M/c SystemMaxUse=50M' /etc/systemd/journald.conf");
+  (void)system("sed -i '/RateLimitInterval=0s/c #RateLimitInterval=30s' /etc/systemd/journald.conf");
+  (void)system("sed -i '/RateLimitBurst=0/c #RateLimitBurst=1000' /etc/systemd/journald.conf");
+  (void)system("service systemd-journald restart");
   return 0;
 }

--- a/src/unit_test/nas_rt_offload_cps_unittest.cpp
+++ b/src/unit_test/nas_rt_offload_cps_unittest.cpp
@@ -98,14 +98,14 @@ static cps_api_return_code_t nas_ut_rt_cfg (bool is_add, const char *ip_addr, ui
      * CPS transaction
      */
     cps_api_transaction_params_t tr;
-    cps_api_transaction_init(&tr);
+    (void)cps_api_transaction_init(&tr);
 
     if (is_add)
         cps_api_create(&tr,obj);
     else
         cps_api_delete(&tr,obj);
 
-    cps_api_commit(&tr);
+    (void)cps_api_commit(&tr);
     cps_api_transaction_close(&tr);
 
     return cps_api_ret_code_OK;
@@ -154,14 +154,14 @@ static cps_api_return_code_t nas_ut_neigh_cfg (bool is_add, const char *ip_addr,
      * CPS transaction
      */
     cps_api_transaction_params_t tr;
-    cps_api_transaction_init(&tr);
+    (void)cps_api_transaction_init(&tr);
 
     if (is_add)
         cps_api_create(&tr,obj);
     else
         cps_api_delete(&tr,obj);
 
-    cps_api_commit(&tr);
+    (void)cps_api_commit(&tr);
 
     cps_api_transaction_close(&tr);
 

--- a/src/unit_test/nas_rt_rif_test.py
+++ b/src/unit_test/nas_rt_rif_test.py
@@ -78,7 +78,7 @@ def exec_shell(cmd):
 def get_sw_mode():
     global mode
     mode = 'OPX'
-    ret = exec_shell('opx-show-version | grep \"OS_NAME.*Enterprise\"')
+    ret = exec_shell('os10-show-version | grep \"OS_NAME.*Enterprise\"')
     if ret:
         mode = 'DoD'
 

--- a/src/unit_test/nas_rt_util_unittest.h
+++ b/src/unit_test/nas_rt_util_unittest.h
@@ -32,13 +32,15 @@
 #include "cps_api_object_key.h"
 
 cps_api_return_code_t nas_ut_rt_cfg (const char *rt_vrf_name, bool is_add, const char *ip_addr, uint32_t prefix_len,
-                                     uint8_t af, const char *nh_vrf_name, const char *nh_addr, const char *if_name);
+                                     uint8_t af, const char *nh_vrf_name, const char *nh_addr, const char *if_name, bool is_onlink_nh=false,
+                                     bool is_replace=false);
 cps_api_return_code_t nas_ut_neigh_cfg (bool is_add, const char *ip_addr, uint8_t af, const char *if_name, hal_mac_addr_t *hw_addr);
 void nas_route_dump_arp_object_content(cps_api_object_t obj);
 cps_api_return_code_t nas_ut_validate_neigh_cfg (const char *vrf_name, uint32_t af, const char *ip_addr,
                                                  uint32_t state, bool should_exist_in_npu, const char *nh_vrf_name);
 cps_api_return_code_t nas_ut_validate_rt_cfg (const char *rt_vrf_name, uint32_t af, const char *ip_addr, uint32_t prefix_len,
-                                              const char *nh_vrf_name, const char *nh_addr, const char *if_name, bool should_exist_in_npu);
+                                              const char *nh_vrf_name, const char *nh_addr, const char *if_name, bool should_exist_in_npu,
+                                              bool is_onlink_nh=false);
 cps_api_return_code_t nas_ut_validate_rt_ecmp_cfg (const char *rt_vrf_name, uint32_t af, const char *ip_addr, uint32_t prefix_len,
                                               const char *nh_vrf_name, const char *nh_addr, const char *if_name, bool should_exist_in_npu,
                                               uint32_t rt_nh_cnt);

--- a/src/unit_test/virtual_routing_ip_cfg_test.py
+++ b/src/unit_test/virtual_routing_ip_cfg_test.py
@@ -97,7 +97,7 @@ def handle_show(vrf, af, ifname, ip):
 def test_pre_req_cfg():
     #print("Test pre requisite config")
     mode = 'OPX'
-    ret = exec_shell('opx-show-version | grep \"OS_NAME.*Enterprise\"')
+    ret = exec_shell('os10-show-version | grep \"OS_NAME.*Enterprise\"')
     if ret:
         mode = 'DoD'
 


### PR DESCRIPTION
feat: opx-nas-l3 for OPX-3.2.0
  * Update: Avoid the ARP/Nbr refresh when the MAC not learnt in the kernel
  * Bugfix: Added the NULL check for NH to avoid the crash during best route get for NHT destination.
  * Update: Use the right size for the vrf-name
  * Update: Addressed the zero MAC with VXLAN intf case.
  * Update: Trigger ARP refresh when VXLAN remote MAC moves from one VTEP to another.

Signed-off-by: Rakesh Datta <rakesh.datta@dell.com>